### PR TITLE
[RSDK-7953]   Consolidate build workflow for all archs part 2

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration test using mediamtx
 
-# on: [push, pull_request]
+on: [push, pull_request]
 
 jobs:
   build-and-test:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration test using mediamtx
 
-on: [push, pull_request]
+# on: [push, pull_request]
 
 jobs:
   build-and-test:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration test using mediamtx
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build-and-test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            canon_command: canon --profile viam-rtsp-antique
+          # - platform: linux/amd64
+          #   runner: ubuntu-latest
+          #   target_os: linux
+          #   target_arch: amd64
           - platform: linux/arm64
             runner: buildjet-8vcpu-ubuntu-2204-arm
-            canon_command: canon --profile viam-rtsp-antique
+            target_os: linux
+            target_arch: arm64
           - platform: android/arm64
             runner: buildjet-8vcpu-ubuntu-2204-arm
-            canon_command: canon --profile viam-rtsp-antique
+            target_os: android
+            target_arch: arm64
       
     runs-on: ${{ matrix.runner }}
 
@@ -40,16 +43,8 @@ jobs:
 
     - name: Build and package
       run: |
-        if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-          ${{ matrix.canon_command }}
-          TARGET_OS=linux TARGET_ARCH=amd64 make module
-        elif [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          ${{ matrix.canon_command }}
-          TARGET_OS=linux TARGET_ARCH=arm64 make module
-        elif [[ "${{ matrix.platform }}" == "android/arm64" ]]; then
-          ${{ matrix.canon_command }}
-          TARGET_OS=android TARGET_ARCH=arm64 make module
-        fi
+        canon --profile viam-rtsp-antique
+        TARGET_OS=${{ matrix.target_os }} TARGET_ARCH=${{ matrix.target_arch }} make module
 
     - name: Upload viamrtsp module to registry
       uses: viamrobotics/upload-module@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,11 @@ jobs:
             runner: buildjet-8vcpu-ubuntu-2204-arm
             target_os: linux
             target_arch: arm64
-          - platform: android/arm64
-            runner: ubuntu-latest
-            target_os: android
-            target_arch: arm64
-      
+          # - platform: android/arm64
+          #   runner: ubuntu-latest
+          #   target_os: android
+          #   target_arch: arm64
+
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -34,16 +34,19 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.23
+        go-version: 1.21.13
 
-    - name: Install canon
+    - name: Install canon (only for non-Android platforms)
+      if: ${{ matrix.target_os != 'android' }}
       run: |
         export PATH="$(go env GOPATH)/bin:$PATH"
-        go install github.com/viamrobotics/canon@v1.1.1
+        go install github.com/viamrobotics/canon@v1.0.0
 
     - name: Build and package
       run: |
-        canon --profile viam-rtsp-antique
+        if [ "${{ matrix.target_os }}" != "android" ]; then
+          canon --profile viam-rtsp-antique
+        fi
         TARGET_OS=${{ matrix.target_os }} TARGET_ARCH=${{ matrix.target_arch }} make module
 
     - name: Upload viamrtsp module to registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,26 @@
 name: Build & publish module to registry
 
 on:
-  push:
-    branches:
-      - '*'
-  pull_request:
-    branches:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   publish:
     strategy:
       matrix:
         include:
-          # - platform: linux/amd64
-          #   runner: ubuntu-latest
-          #   target_os: linux
-          #   target_arch: amd64
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            target_os: linux
+            target_arch: amd64
           - platform: linux/arm64
             runner: buildjet-8vcpu-ubuntu-2204-arm
             target_os: linux
             target_arch: arm64
-          # - platform: android/arm64
-          #   runner: ubuntu-latest
-          #   target_os: android
-          #   target_arch: arm64
+          - platform: android/arm64
+            runner: ubuntu-latest
+            target_os: android
+            target_arch: arm64
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,6 @@ jobs:
           canon -profile viam-rtsp-antique -arch arm64
         fi
 
-    - name: Install deps inside Canon
-      run: |
-        canon sudo apt-get update
-        canon sudo apt-get install -y ffmpeg
-
     - name: Build and package
       run: |
         if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,12 @@
 name: Build & publish module to registry
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   publish:
@@ -18,16 +22,34 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21.13
+        go-version: 1.23
+
+    - name: Install canon
+      run: |
+        export PATH="$(go env GOPATH)/bin:$PATH"
+        go install github.com/viamrobotics/canon@latest
+    
+    - name: Launch canon
+      run: |
+        if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
+          canon -profile viam-rtsp-antique -arch amd64
+        else
+          canon -profile viam-rtsp-antique -arch arm64
+        fi
+
+    - name: Install deps inside Canon
+      run: |
+        canon sudo apt-get update
+        canon sudo apt-get install -y ffmpeg
 
     - name: Build and package
       run: |
         if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-          TARGET_OS=linux TARGET_ARCH=amd64 make module
+          canon TARGET_OS=linux TARGET_ARCH=amd64 make module
         elif [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          TARGET_OS=linux TARGET_ARCH=arm64 make module
+          canon TARGET_OS=linux TARGET_ARCH=arm64 make module
         elif [[ "${{ matrix.platform }}" == "android/arm64" ]]; then
-          TARGET_OS=android TARGET_ARCH=arm64 make module
+          canon TARGET_OS=android TARGET_ARCH=arm64 make module
         fi
 
     - name: Upload viamrtsp module to registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
             target_os: linux
             target_arch: arm64
           - platform: android/arm64
-            runner: buildjet-8vcpu-ubuntu-2204-arm
+            runner: ubuntu-latest
             target_os: android
             target_arch: arm64
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,22 +29,22 @@ jobs:
         export PATH="$(go env GOPATH)/bin:$PATH"
         go install github.com/viamrobotics/canon@latest
     
-    - name: Launch canon
+    - name: Set canon command with args
       run: |
         if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-          canon -profile viam-rtsp-antique -arch amd64
+          CANON_COMMAND="canon -profile viam-rtsp-antique -arch amd64"
         else
-          canon -profile viam-rtsp-antique -arch arm64
+          CANON_COMMAND="canon -profile viam-rtsp-antique -arch arm64"
         fi
 
     - name: Build and package
       run: |
         if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-          canon TARGET_OS=linux TARGET_ARCH=amd64 make module
+          $CANON_COMMAND TARGET_OS=linux TARGET_ARCH=amd64 make module
         elif [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          canon TARGET_OS=linux TARGET_ARCH=arm64 make module
+          $CANON_COMMAND TARGET_OS=linux TARGET_ARCH=arm64 make module
         elif [[ "${{ matrix.platform }}" == "android/arm64" ]]; then
-          canon TARGET_OS=android TARGET_ARCH=arm64 make module
+          $CANON_COMMAND TARGET_OS=android TARGET_ARCH=arm64 make module
         fi
 
     - name: Upload viamrtsp module to registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,18 @@ jobs:
   publish:
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64, android/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            canon_command: canon --profile viam-rtsp-antique
+          - platform: linux/arm64
+            runner: buildjet-8vcpu-ubuntu-2204-arm
+            canon_command: canon --profile viam-rtsp-antique
+          - platform: android/arm64
+            runner: buildjet-8vcpu-ubuntu-2204-arm
+            canon_command: canon --profile viam-rtsp-antique
       
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'buildjet-8vcpu-ubuntu-2204-arm' }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - uses: actions/checkout@v3
@@ -27,24 +36,19 @@ jobs:
     - name: Install canon
       run: |
         export PATH="$(go env GOPATH)/bin:$PATH"
-        go install github.com/viamrobotics/canon@latest
-    
-    - name: Set canon command with args
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-          CANON_COMMAND="canon -profile viam-rtsp-antique -arch amd64"
-        else
-          CANON_COMMAND="canon -profile viam-rtsp-antique -arch arm64"
-        fi
+        go install github.com/viamrobotics/canon@v1.1.1
 
     - name: Build and package
       run: |
         if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-          $CANON_COMMAND TARGET_OS=linux TARGET_ARCH=amd64 make module
+          ${{ matrix.canon_command }}
+          TARGET_OS=linux TARGET_ARCH=amd64 make module
         elif [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          $CANON_COMMAND TARGET_OS=linux TARGET_ARCH=arm64 make module
+          ${{ matrix.canon_command }}
+          TARGET_OS=linux TARGET_ARCH=arm64 make module
         elif [[ "${{ matrix.platform }}" == "android/arm64" ]]; then
-          $CANON_COMMAND TARGET_OS=android TARGET_ARCH=arm64 make module
+          ${{ matrix.canon_command }}
+          TARGET_OS=android TARGET_ARCH=arm64 make module
         fi
 
     - name: Upload viamrtsp module to registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [linux/amd64, linux/arm64, android/arm64]
       
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'buildjet-8vcpu-ubuntu-2204-arm' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'buildjet-8vcpu-ubuntu-2204-arm' }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
If we were to continue using #44 only, we would lose support for Bullseye. Buildjet arm runners use a newer version of glibc. We should use canon's antique profile. This will also better align our manual test builds with deployed builds.

Update: I added a condition that doesn't use canon for Android. For some reason android builds don't work in the canon docker antique environment. The current android build flow does not use Docker or canon

Tests:
["Successful" linux/arm64 CI run](https://github.com/viam-modules/viamrtsp/actions/runs/10854614809/job/30125433385?pr=48)
["Successful" android/arm64 CI run](https://github.com/viam-modules/viamrtsp/actions/runs/10854576184/job/30125308560)
["Successful" linux/amd64 CI run](https://github.com/viam-modules/viamrtsp/actions/runs/10852087675/job/30117308055)

"successful" in quotes meaning that even though the CI technically failed, it failed on the upload step with a semver error, which is expected since we don't want them to actually upload yet.
