### PR TITLE
[RSDK-8667]   Fix possible edge case for decode wonkiness using pool clear func

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration test using mediamtx
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build-and-test:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,6 @@
 name: Integration test using mediamtx
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build-and-test:

--- a/decoder.go
+++ b/decoder.go
@@ -240,7 +240,8 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 			dst.frame.width, dst.frame.height, d.src.width, d.src.height)
 
 		// Handle size changes while having previously initialized frames to avoid https://github.com/erh/viamrtsp/pull/41#discussion_r1719998891
-		if dst.frame.width > 0 || dst.frame.height > 0 {
+		frameWasPreviouslyInitialized := dst.frame.width > 0 && dst.frame.height > 0
+		if frameWasPreviouslyInitialized {
 			d.avFramePool.clear()
 			// Release old size frame
 			dst.free()

--- a/decoder.go
+++ b/decoder.go
@@ -247,9 +247,9 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 		// Handle size changes while having previously initialized frames to avoid https://github.com/erh/viamrtsp/pull/41#discussion_r1719998891
 		frameWasPreviouslyInitialized := dst.frame.width > 0 && dst.frame.height > 0
 		if frameWasPreviouslyInitialized {
-			// Release previously initialized frames
-			d.avFramePool.clear()
+			// Release previously initialized frames, and block old prev gen frames from returning to pool
 			dst.free()
+			d.avFramePool.clearAndStartNewGeneration()
 			// Make new frame to be initialized with new size
 			newDst, err := newAVFrameWrapper()
 			if err != nil {

--- a/decoder.go
+++ b/decoder.go
@@ -242,9 +242,10 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 		// Handle size changes while having previously initialized frames to avoid https://github.com/erh/viamrtsp/pull/41#discussion_r1719998891
 		frameWasPreviouslyInitialized := dst.frame.width > 0 && dst.frame.height > 0
 		if frameWasPreviouslyInitialized {
+			// Release previously initialized frames
 			d.avFramePool.clear()
-			// Release old size frame
 			dst.free()
+			// Make new frame to be initialized with new size
 			newDst, err := newAVFrameWrapper()
 			if err != nil {
 				return nil, errors.Errorf("AV frame allocation error while decoding: %v", err)
@@ -256,6 +257,7 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 			C.sws_freeContext(d.swsCtx)
 		}
 
+		// Prepare the fresh frame
 		dst.frame.format = C.AV_PIX_FMT_RGBA
 		dst.frame.width = d.src.width
 		dst.frame.height = d.src.height

--- a/pool.go
+++ b/pool.go
@@ -10,7 +10,9 @@ type framePool struct {
 	frames       []*avFrameWrapper
 	maxNumFrames int
 	framesMu     sync.Mutex
-	logger       logging.Logger
+	// The pool's frame format generation. See avFrameWrapper's `generation` doc comment for more context.
+	generation int
+	logger     logging.Logger
 
 	putCount   int
 	getCount   int
@@ -22,6 +24,7 @@ func newFramePool(maxNumFrames int, logger logging.Logger) *framePool {
 	pool := &framePool{
 		frames:       make([]*avFrameWrapper, 0, maxNumFrames),
 		maxNumFrames: maxNumFrames,
+		generation:   0,
 		logger:       logger,
 	}
 
@@ -35,6 +38,7 @@ func (p *framePool) get() *avFrameWrapper {
 	if len(p.frames) == 0 {
 		p.logger.Debug("No frames available in pool. Constructing new frame!")
 		frame, err := newAVFrameWrapper()
+		frame.generation = p.generation // set generation on frame creation
 		if err != nil {
 			p.logger.Errorf("Failed to allocate AVFrame in frame pool: %v", err)
 			return nil
@@ -69,6 +73,14 @@ func (p *framePool) put(frame *avFrameWrapper) {
 	p.framesMu.Lock()
 	defer p.framesMu.Unlock()
 
+	if frame.generation < 0 {
+		panic("fatal error: frame's generation was not set properly by pool")
+	}
+	if p.generation != frame.generation {
+		p.logger.Debug("frame was not returned to pool due to generation difference")
+		return
+	}
+
 	if len(p.frames) >= p.maxNumFrames {
 		frame.free()
 		p.cleanCount++
@@ -90,6 +102,8 @@ func (p *framePool) clear() {
 		frame.free()
 	}
 	p.frames = make([]*avFrameWrapper, 0, p.maxNumFrames)
+
+	p.generation++
 }
 
 func (p *framePool) close() {

--- a/pool.go
+++ b/pool.go
@@ -94,7 +94,7 @@ func (p *framePool) put(frame *avFrameWrapper) {
 	frame.isInPool.Store(true)
 }
 
-func (p *framePool) clear() {
+func (p *framePool) clearAndStartNewGeneration() {
 	p.framesMu.Lock()
 	defer p.framesMu.Unlock()
 

--- a/pool.go
+++ b/pool.go
@@ -82,6 +82,16 @@ func (p *framePool) put(frame *avFrameWrapper) {
 	frame.isInPool.Store(true)
 }
 
+func (p *framePool) clear() {
+	p.framesMu.Lock()
+	defer p.framesMu.Unlock()
+
+	for _, frame := range p.frames {
+		frame.free()
+	}
+	p.frames = make([]*avFrameWrapper, 0, p.maxNumFrames)
+}
+
 func (p *framePool) close() {
 	p.framesMu.Lock()
 	defer p.framesMu.Unlock()


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-8667

> This ticket was created to address Dan’s comment [here](https://github.com/erh/viamrtsp/pull/41#discussion_r1719998891)
> 
> Proposed solution:
> 
> Add an extra conditional where we detect mismatch between dst and source yuv frame that checks if the dst frame already has a defined non-zero height and width (a reused frame). If there is a non-zero dimension mismatch between dst and source yuv, then we know the resolution has changed.
> 
> We should flush the pool (possibly re-seed) to prevent the case Dan outlined with a fast resolution switch.