### PR TITLE
[RSDK-9228] Default RTPPassthrough to true and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following attributes are available for all models of `viamrtsp` cameras:
 | Name    | Type   | Inclusion    | Description |
 | ------- | ------ | ------------ | ----------- |
 | `rtsp_address` | string | **Required** | The RTSP address where the camera streams. |
-| `rtp_passthrough` | bool | Optional | RTP passthrough mode (which improves video streaming efficiency) is supported with the H264 codec if this attribute is set to `true`. <br> Default: `false` |
+| `rtp_passthrough` | bool | Optional | RTP passthrough mode (which improves video streaming efficiency) is supported with the H264 codec. It will be on by default. Set to false to bypass H264 RTP passthrough. <br> Default: `true` |
 
 ### Example configuration
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following attributes are available for all models of `viamrtsp` cameras:
 | Name    | Type   | Inclusion    | Description |
 | ------- | ------ | ------------ | ----------- |
 | `rtsp_address` | string | **Required** | The RTSP address where the camera streams. |
-| `rtp_passthrough` | bool | Optional | RTP passthrough mode (which improves video streaming efficiency) is supported with the H264 codec. It will be on by default. Set to false to bypass H264 RTP passthrough. <br> Default: `true` |
+| `rtp_passthrough` | bool | Optional | RTP passthrough mode (which improves video streaming efficiency) is supported with the H264 codec. It will be on by default. Set to false to disable H264 RTP passthrough. <br> Default: `true` |
 
 ### Example configuration
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -101,7 +101,7 @@ func init() {
 // Config are the config attributes for an RTSP camera model.
 type Config struct {
 	Address          string                             `json:"rtsp_address"`
-	RTPPassthrough   bool                               `json:"rtp_passthrough"`
+	RTPPassthrough   *bool                              `json:"rtp_passthrough"`
 	IntrinsicParams  *transform.PinholeCameraIntrinsics `json:"intrinsic_parameters,omitempty"`
 	DistortionParams *transform.BrownConrady            `json:"distortion_parameters,omitempty"`
 }
@@ -693,11 +693,16 @@ func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 
 	framePool := newFramePool(initialFramePoolSize, logger)
 
+	rtpPassthrough := true
+	if newConf.RTPPassthrough != nil {
+		rtpPassthrough = *newConf.RTPPassthrough
+	}
+
 	rtpPassthroughCtx, rtpPassthroughCancelCauseFn := context.WithCancelCause(context.Background())
 	rc := &rtspCamera{
 		model:                       conf.Model,
 		u:                           u,
-		rtpPassthrough:              newConf.RTPPassthrough,
+		rtpPassthrough:              rtpPassthrough,
 		bufAndCBByID:                make(map[rtppassthrough.SubscriptionID]bufAndCB),
 		rtpPassthroughCtx:           rtpPassthroughCtx,
 		rtpPassthroughCancelCauseFn: rtpPassthroughCancelCauseFn,

--- a/rtsp_test.go
+++ b/rtsp_test.go
@@ -94,7 +94,8 @@ func TestRTSPCamera(t *testing.T) {
 				timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Second*10)
 				defer timeoutCancel()
 				config := resource.NewEmptyConfig(camera.Named("foo"), ModelAgnostic)
-				config.ConvertedAttributes = &Config{Address: "rtsp://" + h.s.RTSPAddress, RTPPassthrough: true}
+				shouldPassthrough := true
+				config.ConvertedAttributes = &Config{Address: "rtsp://" + h.s.RTSPAddress, RTPPassthrough: &shouldPassthrough}
 				rtspCam, err := NewRTSPCamera(timeoutCtx, nil, config, logger)
 				test.That(t, err, test.ShouldBeNil)
 				defer func() { test.That(t, rtspCam.Close(context.Background()), test.ShouldBeNil) }()
@@ -122,14 +123,15 @@ func TestRTSPCamera(t *testing.T) {
 				}
 			})
 
-			t.Run("otherwise", func(t *testing.T) {
+			t.Run("when RTPPassthrough = false", func(t *testing.T) {
 				h, closeFunc := newH264ServerHandler(t, forma, bURL, logger)
 				defer closeFunc()
 				test.That(t, h.s.Start(), test.ShouldBeNil)
 				timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Second*10)
 				defer timeoutCancel()
 				config := resource.NewEmptyConfig(camera.Named("foo"), ModelAgnostic)
-				config.ConvertedAttributes = &Config{Address: "rtsp://" + h.s.RTSPAddress}
+				shouldPassthrough := false
+				config.ConvertedAttributes = &Config{Address: "rtsp://" + h.s.RTSPAddress, RTPPassthrough: &shouldPassthrough}
 				rtspCam, err := NewRTSPCamera(timeoutCtx, nil, config, logger)
 				test.That(t, err, test.ShouldBeNil)
 				defer func() { test.That(t, rtspCam.Close(context.Background()), test.ShouldBeNil) }()


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9228

Manual test (h264)
![Screenshot 2024-11-11 at 12 46 46 PM](https://github.com/user-attachments/assets/3776cf19-3fda-4e20-a50d-dab294b1f65a)
As you can see, it's not specified in the config, but in the logs it indicates rtp passthrough is happening

Also verified that setting the field true results in passthrough still happening, and setting the field to false results in passthrough not happening