### PR TITLE
[RSDK-9688, RSDK-9732, RSDK-9733] Use libav for JPEG encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --disable-everything \
                --enable-decoder=h264 \
                --enable-decoder=hevc \
+               --enable-encoder=mjpeg \
                --enable-network \
                --enable-parser=h264 \
                --enable-parser=hevc

--- a/decoder.go
+++ b/decoder.go
@@ -349,6 +349,7 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 	// Copy the frame properties from the source frame to the destination frame.
 	// This will fill fields not explicitly set in the initial dst frame allocation.
 	if res := C.av_frame_copy_props(dst.frame, d.src); res < 0 {
+		// We should never reach this point if av_frame_copy() succeeded.
 		return nil, newAvError(res, "av_frame_copy_props() failed")
 	}
 

--- a/decoder.go
+++ b/decoder.go
@@ -312,9 +312,10 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 
 	// If the frame from the pool has the wrong size, (re-)initialize it.
 	if dst.frame.width != d.src.width || dst.frame.height != d.src.height || dst.frame.format != d.src.format {
-		d.logger.Debugf("(re)making frame due to AVFrame discrepancy: Dst (width: %d, height: %d, format: %d) vs Src (width: %d, height: %d, format: %d)",
-			dst.frame.width, dst.frame.height, dst.frame.format, d.src.width, d.src.height, d.src.format)
-
+		d.logger.Debugf("(re)making frame due to AVFrame discrepancy: "+
+			"Dst (width: %d, height: %d, format: %d) vs Src (width: %d, height: %d, format: %d)",
+			dst.frame.width, dst.frame.height, dst.frame.format,
+			d.src.width, d.src.height, d.src.format)
 		// Handle size changes while having previously initialized frames to avoid https://github.com/erh/viamrtsp/pull/41#discussion_r1719998891
 		frameWasPreviouslyInitialized := dst.frame.width > 0 && dst.frame.height > 0
 		if frameWasPreviouslyInitialized {

--- a/decoder.go
+++ b/decoder.go
@@ -138,7 +138,7 @@ func (w *avFrameWrapper) toImage() image.Image {
 	crDataPtr := unsafe.Pointer(w.frame.data[2])
 	crSlice := (*[1 << 30]byte)(crDataPtr)[:cPlaneSize:cPlaneSize]
 
-	ycbcr := &image.YCbCr{
+	return &image.YCbCr{
 		Y:              ySlice,
 		Cb:             cbSlice,
 		Cr:             crSlice,
@@ -147,8 +147,6 @@ func (w *avFrameWrapper) toImage() image.Image {
 		SubsampleRatio: image.YCbCrSubsampleRatio420,
 		Rect:           image.Rect(0, 0, width, height),
 	}
-
-	return ycbcr
 }
 
 // newAVFrameWrapper allocates a new AVFrame using C code with safety checks and returns the Go wrapper of it.

--- a/decoder.go
+++ b/decoder.go
@@ -100,18 +100,55 @@ func (w *avFrameWrapper) free() {
 	}
 }
 
-// toImage takes the underlying av frame and embeds it into a RGBA image struct.
-func (w *avFrameWrapper) toImage() image.Image {
-	dstFrameSize := C.av_image_get_buffer_size((int32)(w.frame.format), w.frame.width, w.frame.height, 1)
-	dstFramePtr := (*[1 << 30]uint8)(unsafe.Pointer(w.frame.data[0]))[:dstFrameSize:dstFrameSize]
-
-	return &image.RGBA{
-		Pix:    dstFramePtr,
-		Stride: bytesPerPixel * (int)(w.frame.width),
-		Rect: image.Rectangle{
-			Max: image.Point{(int)(w.frame.width), (int)(w.frame.height)},
-		},
+// toImageYCbCr maps the underlying AVFrame (in YUV420P format) to a Go image.YCbCr.
+// Returns nil if frame is not AV_PIX_FMT_YUV420P or if something goes wrong.
+func (w *avFrameWrapper) toImageYCbCr() image.Image {
+	// Ensure the frame format is YUV420P.
+	if w.frame.format != C.AV_PIX_FMT_YUV420P {
+		return nil
 	}
+
+	width := int(w.frame.width)
+	height := int(w.frame.height)
+
+	// Strides (a.k.a. linesize in FFmpeg).
+	// For YUV420P:
+	//   - data[0] = Y plane, linesize[0] = stride for Y
+	//   - data[1] = U plane, linesize[1] = stride for U
+	//   - data[2] = V plane, linesize[2] = stride for V
+	yStride := int(w.frame.linesize[0])
+	cStride := int(w.frame.linesize[1])
+
+	// Number of bytes in each plane.
+	// Y plane is full resolution: height * yStride
+	// U and V planes are half resolution in both dimensions: (height/2) * cStride
+	yPlaneSize := yStride * height
+	cPlaneSize := cStride * (height / 2)
+
+	// Map the Y plane into a Go slice.
+	yDataPtr := unsafe.Pointer(w.frame.data[0])
+	ySlice := (*[1 << 30]byte)(yDataPtr)[:yPlaneSize:yPlaneSize]
+
+	// Map the U (Cb) plane into a Go slice.
+	cbDataPtr := unsafe.Pointer(w.frame.data[1])
+	cbSlice := (*[1 << 30]byte)(cbDataPtr)[:cPlaneSize:cPlaneSize]
+
+	// Map the V (Cr) plane into a Go slice.
+	crDataPtr := unsafe.Pointer(w.frame.data[2])
+	crSlice := (*[1 << 30]byte)(crDataPtr)[:cPlaneSize:cPlaneSize]
+
+	// Construct the Go image.YCbCr. For YUV420p, the subsample ratio is 4:2:0.
+	ycbcr := &image.YCbCr{
+		Y:              ySlice,
+		Cb:             cbSlice,
+		Cr:             crSlice,
+		YStride:        yStride,
+		CStride:        cStride,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect:           image.Rect(0, 0, width, height),
+	}
+
+	return ycbcr
 }
 
 // newAVFrameWrapper allocates a new AVFrame using C code with safety checks and returns the Go wrapper of it.

--- a/decoder.go
+++ b/decoder.go
@@ -318,7 +318,6 @@ func (d *decoder) decode(nalu []byte) (*avFrameWrapper, error) {
 		// Handle size changes while having previously initialized frames to avoid https://github.com/erh/viamrtsp/pull/41#discussion_r1719998891
 		frameWasPreviouslyInitialized := dst.frame.width > 0 && dst.frame.height > 0
 		if frameWasPreviouslyInitialized {
-			d.logger.Info("Frame was previously initialized. Reinitializing frame due to size change.")
 			// Release previously initialized frames, and block old prev gen frames from returning to pool
 			dst.free()
 			generation := d.avFramePool.clearAndStartNewGeneration()

--- a/decoder.go
+++ b/decoder.go
@@ -104,8 +104,7 @@ func (w *avFrameWrapper) free() {
 	}
 }
 
-// toImageYCbCr maps the underlying AVFrame (in YUV420P format) to a Go image.YCbCr.
-// Returns nil if frame is not AV_PIX_FMT_YUV420P or if something goes wrong.
+// toImage maps the underlying AVFrame (in YUV420P format) to a Go image.YCbCr.
 func (w *avFrameWrapper) toImage() image.Image {
 	if w.frame.format != C.AV_PIX_FMT_YUV420P && w.frame.format != C.AV_PIX_FMT_YUVJ420P {
 		return nil
@@ -113,6 +112,9 @@ func (w *avFrameWrapper) toImage() image.Image {
 
 	width := int(w.frame.width)
 	height := int(w.frame.height)
+	if width <= 0 || height <= 0 {
+		return nil
+	}
 
 	// For YUV420P:
 	//   - data[0] = Y plane, linesize[0] = stride for Y

--- a/mime.go
+++ b/mime.go
@@ -85,7 +85,7 @@ func (mh *mimeHandler) initJPEGEncoder(frame *C.AVFrame) error {
 	mh.jpegEnc.width = frame.width
 	mh.jpegEnc.height = frame.height
 	mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUVJ420P
-	// We don't care about accurate timestamps still frames
+	// We don't care about accurate timestamps for still frames
 	mh.jpegEnc.time_base = C.AVRational{num: 1, den: 1}
 	var opts *C.AVDictionary
 	// Equivalent to 75% quality

--- a/mime.go
+++ b/mime.go
@@ -16,21 +16,21 @@ import (
 	rutils "go.viam.com/rdk/utils"
 )
 
-type MimeHandler struct {
+type mimeHandler struct {
 	logger     logging.Logger
 	jpegSwsCtx *C.struct_SwsContext
 	jpegEnc    *C.AVCodecContext
 	currentPTS int
 }
 
-func newMimeHandler(logger logging.Logger) *MimeHandler {
-	return &MimeHandler{
+func newMimeHandler(logger logging.Logger) *mimeHandler {
+	return &mimeHandler{
 		logger:     logger,
 		currentPTS: 0,
 	}
 }
 
-func (mh *MimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageMetadata, error) {
+func (mh *mimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageMetadata, error) {
 	if mh.jpegEnc == nil || frame.frame.width != mh.jpegEnc.width || frame.frame.height != mh.jpegEnc.height {
 		mh.logger.Info("creating MJPEG encoder with frame size: ", frame.frame.width, "x", frame.frame.height)
 		// Tear down jpeg encoder if we're changing frame size
@@ -76,7 +76,7 @@ func (mh *MimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageM
 	}, nil
 }
 
-func (mh *MimeHandler) close() {
+func (mh *mimeHandler) close() {
 	if mh.jpegEnc != nil {
 		C.avcodec_free_context(&mh.jpegEnc)
 	}

--- a/mime.go
+++ b/mime.go
@@ -4,9 +4,6 @@ package viamrtsp
 #cgo pkg-config: libavutil libavcodec
 #include <libavcodec/avcodec.h>
 #include <libavutil/error.h>
-#include <libavutil/opt.h>
-#include <libavutil/dict.h>
-#include <stdlib.h>
 */
 import "C"
 
@@ -23,7 +20,6 @@ type mimeHandler struct {
 	logger     logging.Logger
 	jpegSwsCtx *C.struct_SwsContext
 	jpegEnc    *C.AVCodecContext
-	jpegPkt    *C.AVPacket
 	currentPTS int
 }
 
@@ -47,28 +43,35 @@ func (mh *mimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageM
 		mh.jpegEnc = C.avcodec_alloc_context3(codec)
 		mh.jpegEnc.width = frame.frame.width
 		mh.jpegEnc.height = frame.frame.height
-		mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUV420P
+		mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUVJ420P
 		// We don't care about accurate timestamps still frames
 		mh.jpegEnc.time_base = C.AVRational{num: 1, den: 1}
 		var opts *C.AVDictionary
-		defer C.av_dict_free(&opts)
 		// Equivalent to 75% quality
-		res := C.av_dict_set(&opts, C.CString("qscale"), C.CString("8"), 0)
+		qscaleKey := C.CString("qscale")
+		qscaleValue := C.CString("8")
+		defer func() {
+			C.free(unsafe.Pointer(qscaleValue))
+			C.free(unsafe.Pointer(qscaleKey))
+			C.av_dict_free(&opts)
+		}()
+		res := C.av_dict_set(&opts, qscaleKey, qscaleValue, 0)
 		if res < 0 {
 			return nil, camera.ImageMetadata{}, newAvError(res, "failed to set qscale option")
 		}
 		if res := C.avcodec_open2(mh.jpegEnc, codec, nil); res < 0 {
 			return nil, camera.ImageMetadata{}, newAvError(res, "failed to open MJPEG encoder")
 		}
-		mh.jpegPkt = C.av_packet_alloc()
-		if mh.jpegPkt == nil {
-			return nil, camera.ImageMetadata{}, errors.New("failed to allocate packet")
-		}
 	}
 	if mh.jpegEnc == nil {
 		return nil, camera.ImageMetadata{}, errors.New("failed to create encoder or destination frame")
 	}
-
+	// Allocate a fresh packet to prevent issues with concurrent jpeg encoding
+	pkt := C.av_packet_alloc()
+	if pkt == nil {
+		return nil, camera.ImageMetadata{}, errors.New("failed to allocate packet")
+	}
+	defer C.av_packet_free(&pkt)
 	frame.frame.pts = C.int64_t(mh.currentPTS)
 	// If this reaches max int, it will wrap around to 0
 	mh.currentPTS++
@@ -76,14 +79,12 @@ func (mh *mimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageM
 	if res < 0 {
 		return nil, camera.ImageMetadata{}, newAvError(res, "failed to send frame to MJPEG encoder")
 	}
-	res = C.avcodec_receive_packet(mh.jpegEnc, mh.jpegPkt)
+	res = C.avcodec_receive_packet(mh.jpegEnc, pkt)
 	if res < 0 {
 		return nil, camera.ImageMetadata{}, newAvError(res, "failed to receive packet from MJPEG encoder")
 	}
 	// There is no need to create a frame for the packet, as the packet already contains the data
-	dataGo := C.GoBytes(unsafe.Pointer(mh.jpegPkt.data), mh.jpegPkt.size)
-
-	C.av_packet_unref(mh.jpegPkt)
+	dataGo := C.GoBytes(unsafe.Pointer(pkt.data), pkt.size)
 
 	return dataGo, camera.ImageMetadata{
 		MimeType: rutils.MimeTypeJPEG,

--- a/mime.go
+++ b/mime.go
@@ -36,43 +36,9 @@ func newMimeHandler(logger logging.Logger) *mimeHandler {
 
 func (mh *mimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageMetadata, error) {
 	if mh.jpegEnc == nil || frame.frame.width != mh.jpegEnc.width || frame.frame.height != mh.jpegEnc.height {
-		// Lock to prevent modifying encoder while it is being used concurrently.
-		// Frame param changes are rare, so we can afford to block here.
-		mh.mu.Lock()
-		mh.logger.Info("creating MJPEG encoder with frame size: ", frame.frame.width, "x", frame.frame.height)
-		if mh.jpegEnc != nil {
-			C.avcodec_free_context(&mh.jpegEnc)
+		if err := mh.initJPEGEncoder(frame); err != nil {
+			return nil, camera.ImageMetadata{}, err
 		}
-		codec := C.avcodec_find_encoder(C.AV_CODEC_ID_MJPEG)
-		if codec == nil {
-			mh.mu.Unlock()
-			return nil, camera.ImageMetadata{}, errors.New("failed to find MJPEG encoder")
-		}
-		mh.jpegEnc = C.avcodec_alloc_context3(codec)
-		mh.jpegEnc.width = frame.frame.width
-		mh.jpegEnc.height = frame.frame.height
-		mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUVJ420P
-		// We don't care about accurate timestamps still frames
-		mh.jpegEnc.time_base = C.AVRational{num: 1, den: 1}
-		var opts *C.AVDictionary
-		// Equivalent to 75% quality
-		qscaleKey := C.CString("qscale")
-		qscaleValue := C.CString("8")
-		defer func() {
-			C.free(unsafe.Pointer(qscaleValue))
-			C.free(unsafe.Pointer(qscaleKey))
-			C.av_dict_free(&opts)
-		}()
-		res := C.av_dict_set(&opts, qscaleKey, qscaleValue, 0)
-		if res < 0 {
-			mh.mu.Unlock()
-			return nil, camera.ImageMetadata{}, newAvError(res, "failed to set qscale option")
-		}
-		if res := C.avcodec_open2(mh.jpegEnc, codec, nil); res < 0 {
-			mh.mu.Unlock()
-			return nil, camera.ImageMetadata{}, newAvError(res, "failed to open MJPEG encoder")
-		}
-		mh.mu.Unlock()
 	}
 	if mh.jpegEnc == nil {
 		return nil, camera.ImageMetadata{}, errors.New("failed to create encoder or destination frame")
@@ -100,6 +66,45 @@ func (mh *mimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageM
 	return dataGo, camera.ImageMetadata{
 		MimeType: rutils.MimeTypeJPEG,
 	}, nil
+}
+
+func (mh *mimeHandler) initJPEGEncoder(frame *avFrameWrapper) error {
+	// Lock to prevent modifying encoder while it is being used concurrently.
+	// Frame param changes are rare, so we can afford to block here.
+	mh.mu.Lock()
+	defer mh.mu.Unlock()
+	mh.logger.Info("creating MJPEG encoder with frame size: ", frame.frame.width, "x", frame.frame.height)
+	if mh.jpegEnc != nil {
+		C.avcodec_free_context(&mh.jpegEnc)
+	}
+	codec := C.avcodec_find_encoder(C.AV_CODEC_ID_MJPEG)
+	if codec == nil {
+		return errors.New("failed to find MJPEG encoder")
+	}
+	mh.jpegEnc = C.avcodec_alloc_context3(codec)
+	mh.jpegEnc.width = frame.frame.width
+	mh.jpegEnc.height = frame.frame.height
+	mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUVJ420P
+	// We don't care about accurate timestamps still frames
+	mh.jpegEnc.time_base = C.AVRational{num: 1, den: 1}
+	var opts *C.AVDictionary
+	// Equivalent to 75% quality
+	qscaleKey := C.CString("qscale")
+	qscaleValue := C.CString("8")
+	defer func() {
+		C.free(unsafe.Pointer(qscaleValue))
+		C.free(unsafe.Pointer(qscaleKey))
+		C.av_dict_free(&opts)
+	}()
+	res := C.av_dict_set(&opts, qscaleKey, qscaleValue, 0)
+	if res < 0 {
+		return newAvError(res, "failed to set qscale option")
+	}
+	if res := C.avcodec_open2(mh.jpegEnc, codec, nil); res < 0 {
+		return newAvError(res, "failed to open MJPEG encoder")
+	}
+
+	return nil
 }
 
 func (mh *mimeHandler) close() {

--- a/mime.go
+++ b/mime.go
@@ -1,20 +1,82 @@
 package viamrtsp
 
+/*
+#cgo pkg-config: libavutil libavcodec
+#include <libavcodec/avcodec.h>
+#include <libavutil/error.h>
+*/
+import "C"
+
 import (
-	"bytes"
-	"image"
-	"image/jpeg"
+	"fmt"
+	"unsafe"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/logging"
 	rutils "go.viam.com/rdk/utils"
 )
 
-func encodeToJPEG(img image.Image) ([]byte, camera.ImageMetadata, error) {
-	buf := new(bytes.Buffer)
-	if err := jpeg.Encode(buf, img, nil); err != nil {
-		return nil, camera.ImageMetadata{}, err
+type MimeHandler struct {
+	logger     logging.Logger
+	jpegSwsCtx *C.struct_SwsContext
+	jpegEnc    *C.AVCodecContext
+	currentPTS int
+}
+
+func newMimeHandler(logger logging.Logger) *MimeHandler {
+	return &MimeHandler{
+		logger:     logger,
+		currentPTS: 0,
 	}
-	return buf.Bytes(), camera.ImageMetadata{
+}
+
+func (mh *MimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageMetadata, error) {
+	if mh.jpegEnc == nil || frame.frame.width != mh.jpegEnc.width || frame.frame.height != mh.jpegEnc.height {
+		mh.logger.Info("creating MJPEG encoder with frame size: ", frame.frame.width, "x", frame.frame.height)
+		// Tear down jpeg encoder if we're changing frame size
+		if mh.jpegEnc != nil {
+			C.avcodec_free_context(&mh.jpegEnc)
+		}
+		codec := C.avcodec_find_encoder(C.AV_CODEC_ID_MJPEG)
+		if codec == nil {
+			return nil, camera.ImageMetadata{}, fmt.Errorf("failed to find MJPEG encoder")
+		}
+		mh.jpegEnc = C.avcodec_alloc_context3(codec)
+		mh.jpegEnc.width = frame.frame.width
+		mh.jpegEnc.height = frame.frame.height
+		mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUVJ420P
+		mh.jpegEnc.time_base = C.AVRational{num: 1, den: 1} // We don't care about time base for still images
+		if res := C.avcodec_open2(mh.jpegEnc, codec, nil); res < 0 {
+			return nil, camera.ImageMetadata{}, fmt.Errorf("failed to open codec: %d", res)
+		}
+	}
+	if mh.jpegEnc == nil {
+		return nil, camera.ImageMetadata{}, fmt.Errorf("failed to create encoder or destination frame")
+	}
+	pkt := C.av_packet_alloc()
+	if pkt == nil {
+		return nil, camera.ImageMetadata{}, fmt.Errorf("failed to allocate packet")
+	}
+	frame.frame.pts = C.int64_t(mh.currentPTS)
+	mh.currentPTS++
+	defer C.av_packet_free(&pkt)
+	res := C.avcodec_send_frame(mh.jpegEnc, frame.frame)
+	if res < 0 {
+		return nil, camera.ImageMetadata{}, fmt.Errorf("failed to send frame: %d", res)
+	}
+	res = C.avcodec_receive_packet(mh.jpegEnc, pkt)
+	if res < 0 {
+		return nil, camera.ImageMetadata{}, fmt.Errorf("failed to receive packet: %d", res)
+	}
+	dataGo := C.GoBytes(unsafe.Pointer(pkt.data), pkt.size)
+
+	return dataGo, camera.ImageMetadata{
 		MimeType: rutils.MimeTypeJPEG,
 	}, nil
+}
+
+func (mh *MimeHandler) close() {
+	if mh.jpegEnc != nil {
+		C.avcodec_free_context(&mh.jpegEnc)
+	}
 }

--- a/mime.go
+++ b/mime.go
@@ -47,7 +47,7 @@ func (mh *mimeHandler) convertJPEG(frame *avFrameWrapper) ([]byte, camera.ImageM
 		mh.jpegEnc = C.avcodec_alloc_context3(codec)
 		mh.jpegEnc.width = frame.frame.width
 		mh.jpegEnc.height = frame.frame.height
-		mh.jpegEnc.pix_fmt = (C.enum_AVPixelFormat)(frame.frame.format)
+		mh.jpegEnc.pix_fmt = C.AV_PIX_FMT_YUV420P
 		// We don't care about accurate timestamps still frames
 		mh.jpegEnc.time_base = C.AVRational{num: 1, den: 1}
 		var opts *C.AVDictionary

--- a/mime_cgo.go
+++ b/mime_cgo.go
@@ -51,6 +51,7 @@ func createBadFrame() *C.AVFrame {
 	frame.format = C.AV_PIX_FMT_NONE
 	frame.width = 0
 	frame.height = 0
+
 	return frame
 }
 
@@ -63,23 +64,21 @@ func fillDummyYUV420PData(frame *C.AVFrame) {
 	vPlane := (*[1 << 30]uint8)(unsafe.Pointer(frame.data[2]))[: width*height/4 : width*height/4]
 
 	// Fill Y plane
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
-			yPlane[y*int(frame.linesize[0])+x] = 128 // Dummy value for Y
+	for y := range height {
+		for x := range width {
+			yPlane[y*int(frame.linesize[0])+x] = 128
 		}
 	}
-
 	// Fill U plane
-	for y := 0; y < height/2; y++ {
-		for x := 0; x < width/2; x++ {
-			uPlane[y*int(frame.linesize[1])+x] = 64 // Dummy value for U
+	for y := range height / 2 {
+		for x := range width / 2 {
+			uPlane[y*int(frame.linesize[1])+x] = 64
 		}
 	}
-
 	// Fill V plane
-	for y := 0; y < height/2; y++ {
-		for x := 0; x < width/2; x++ {
-			vPlane[y*int(frame.linesize[2])+x] = 64 // Dummy value for V
+	for y := range height / 2 {
+		for x := range width / 2 {
+			vPlane[y*int(frame.linesize[2])+x] = 64
 		}
 	}
 }

--- a/mime_cgo.go
+++ b/mime_cgo.go
@@ -43,7 +43,7 @@ func createTestYUVJ420PFrame(width, height int) *C.AVFrame {
 	return createTestFrame(width, height, C.AV_PIX_FMT_YUVJ420P)
 }
 
-func createBadFrame() *C.AVFrame {
+func createInvalidFrame() *C.AVFrame {
 	frame := C.av_frame_alloc()
 	if frame == nil {
 		return nil

--- a/mime_cgo.go
+++ b/mime_cgo.go
@@ -1,0 +1,89 @@
+package viamrtsp
+
+/*
+#cgo pkg-config: libavutil libavcodec
+#include <libavcodec/avcodec.h>
+#include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+// This is a CGO helper file for mime_test.go. We cannot use CGO directly in test files
+// so we have to place C interop code here.
+
+func createTestFrame(width, height int, format C.enum_AVPixelFormat) *C.AVFrame {
+	frame := C.av_frame_alloc()
+	if frame == nil {
+		return nil
+	}
+	frame.format = C.int(format)
+	frame.width = C.int(width)
+	frame.height = C.int(height)
+	if res := C.av_frame_get_buffer(frame, 32); res < 0 {
+		// If this fails, free the frame and return nil
+		C.av_frame_free(&frame)
+		return nil
+	}
+	// Mark frame as writable, so we can safely fill the data arrays.
+	if res := C.av_frame_make_writable(frame); res < 0 {
+		C.av_frame_free(&frame)
+		return nil
+	}
+
+	return frame
+}
+
+func createTestYUV420PFrame(width, height int) *C.AVFrame {
+	return createTestFrame(width, height, C.AV_PIX_FMT_YUV420P)
+}
+
+func createTestYUVJ420PFrame(width, height int) *C.AVFrame {
+	return createTestFrame(width, height, C.AV_PIX_FMT_YUVJ420P)
+}
+
+func createBadFrame() *C.AVFrame {
+	frame := C.av_frame_alloc()
+	if frame == nil {
+		return nil
+	}
+	frame.format = C.AV_PIX_FMT_NONE
+	frame.width = 0
+	frame.height = 0
+	return frame
+}
+
+func fillDummyYUV420PData(frame *C.AVFrame) {
+	width := int(frame.width)
+	height := int(frame.height)
+
+	yPlane := (*[1 << 30]uint8)(unsafe.Pointer(frame.data[0]))[: width*height : width*height]
+	uPlane := (*[1 << 30]uint8)(unsafe.Pointer(frame.data[1]))[: width*height/4 : width*height/4]
+	vPlane := (*[1 << 30]uint8)(unsafe.Pointer(frame.data[2]))[: width*height/4 : width*height/4]
+
+	// Fill Y plane
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			yPlane[y*int(frame.linesize[0])+x] = 128 // Dummy value for Y
+		}
+	}
+
+	// Fill U plane
+	for y := 0; y < height/2; y++ {
+		for x := 0; x < width/2; x++ {
+			uPlane[y*int(frame.linesize[1])+x] = 64 // Dummy value for U
+		}
+	}
+
+	// Fill V plane
+	for y := 0; y < height/2; y++ {
+		for x := 0; x < width/2; x++ {
+			vPlane[y*int(frame.linesize[2])+x] = 64 // Dummy value for V
+		}
+	}
+}
+
+func freeFrame(frame *C.AVFrame) {
+	C.av_frame_free(&frame)
+}

--- a/mime_test.go
+++ b/mime_test.go
@@ -46,6 +46,7 @@ func TestJPEGConvert(t *testing.T) {
 		mh := newMimeHandler(logger)
 		bytes, metadata, err := mh.convertJPEG(frame)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to open MJPEG encoder")
 		test.That(t, bytes, test.ShouldBeNil)
 		test.That(t, metadata.MimeType, test.ShouldBeEmpty)
 	})

--- a/mime_test.go
+++ b/mime_test.go
@@ -1,0 +1,58 @@
+package viamrtsp
+
+import (
+	"testing"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+func TestJPEGConvert(t *testing.T) {
+	t.Run("valid YUV420P frame succeeds", func(t *testing.T) {
+		width, height := 640, 480
+		frame := createTestYUV420PFrame(width, height)
+		if frame == nil {
+			t.Fatalf("failed to allocate YUV420P frame")
+		}
+		defer freeFrame(frame)
+		fillDummyYUV420PData(frame)
+		logger := logging.NewDebugLogger("mime_test")
+		mh := newMimeHandler(logger)
+		bytes, metadata, err := mh.convertJPEG(frame)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, bytes, test.ShouldNotBeNil)
+		test.That(t, len(bytes), test.ShouldBeGreaterThan, 0)
+		test.That(t, metadata, test.ShouldNotBeEmpty)
+	})
+
+	t.Run("valid YUVJ420P frame succeeds", func(t *testing.T) {
+		width, height := 640, 480
+		frame := createTestYUVJ420PFrame(width, height)
+		if frame == nil {
+			t.Fatalf("failed to allocate YUV420P frame")
+		}
+		defer freeFrame(frame)
+		fillDummyYUV420PData(frame)
+		logger := logging.NewDebugLogger("mime_test")
+		mh := newMimeHandler(logger)
+		bytes, metadata, err := mh.convertJPEG(frame)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, bytes, test.ShouldNotBeNil)
+		test.That(t, len(bytes), test.ShouldBeGreaterThan, 0)
+		test.That(t, metadata, test.ShouldNotBeEmpty)
+	})
+
+	t.Run("invalid frame fails", func(t *testing.T) {
+		frame := createBadFrame()
+		if frame == nil {
+			t.Fatalf("failed to allocate bad frame")
+		}
+		defer freeFrame(frame)
+		logger := logging.NewDebugLogger("mime_test")
+		mh := newMimeHandler(logger)
+		bytes, metadata, err := mh.convertJPEG(frame)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, bytes, test.ShouldBeNil)
+		test.That(t, metadata.MimeType, test.ShouldBeEmpty)
+	})
+}

--- a/mime_test.go
+++ b/mime_test.go
@@ -39,7 +39,7 @@ func TestJPEGConvert(t *testing.T) {
 	})
 
 	t.Run("invalid frame fails", func(t *testing.T) {
-		frame := createBadFrame()
+		frame := createInvalidFrame()
 		test.That(t, frame, test.ShouldNotBeNil)
 		defer freeFrame(frame)
 		logger := logging.NewDebugLogger("mime_test")

--- a/mime_test.go
+++ b/mime_test.go
@@ -11,9 +11,7 @@ func TestJPEGConvert(t *testing.T) {
 	t.Run("valid YUV420P frame succeeds", func(t *testing.T) {
 		width, height := 640, 480
 		frame := createTestYUV420PFrame(width, height)
-		if frame == nil {
-			t.Fatalf("failed to allocate YUV420P frame")
-		}
+		test.That(t, frame, test.ShouldNotBeNil)
 		defer freeFrame(frame)
 		fillDummyYUV420PData(frame)
 		logger := logging.NewDebugLogger("mime_test")
@@ -28,9 +26,7 @@ func TestJPEGConvert(t *testing.T) {
 	t.Run("valid YUVJ420P frame succeeds", func(t *testing.T) {
 		width, height := 640, 480
 		frame := createTestYUVJ420PFrame(width, height)
-		if frame == nil {
-			t.Fatalf("failed to allocate YUV420P frame")
-		}
+		test.That(t, frame, test.ShouldNotBeNil)
 		defer freeFrame(frame)
 		fillDummyYUV420PData(frame)
 		logger := logging.NewDebugLogger("mime_test")
@@ -44,9 +40,7 @@ func TestJPEGConvert(t *testing.T) {
 
 	t.Run("invalid frame fails", func(t *testing.T) {
 		frame := createBadFrame()
-		if frame == nil {
-			t.Fatalf("failed to allocate bad frame")
-		}
+		test.That(t, frame, test.ShouldNotBeNil)
 		defer freeFrame(frame)
 		logger := logging.NewDebugLogger("mime_test")
 		mh := newMimeHandler(logger)

--- a/rtsp.go
+++ b/rtsp.go
@@ -935,7 +935,7 @@ func (rc *rtspCamera) getAndConvertFrame() ([]byte, camera.ImageMetadata, error)
 	}
 	currentFrame := rc.latestFrame
 	currentFrame.incrementRefs()
-	bytes, metdata, err := rc.mimeHandler.convertJPEG(currentFrame)
+	bytes, metdata, err := rc.mimeHandler.convertJPEG(currentFrame.frame)
 	if refCount := currentFrame.decrementRefs(); refCount == 0 {
 		rc.avFramePool.put(currentFrame)
 	}

--- a/rtsp.go
+++ b/rtsp.go
@@ -936,7 +936,6 @@ func (rc *rtspCamera) getAndConvertFrame() ([]byte, camera.ImageMetadata, error)
 	currentFrame := rc.latestFrame
 	currentFrame.incrementRefs()
 	bytes, metdata, err := rc.mimeHandler.convertJPEG(currentFrame)
-	// TODO(seanp): Can I defer this?
 	if refCount := currentFrame.decrementRefs(); refCount == 0 {
 		rc.avFramePool.put(currentFrame)
 	}

--- a/rtsp.go
+++ b/rtsp.go
@@ -177,7 +177,7 @@ type rtspCamera struct {
 	// is responsible for the underlying frame contents and further initializing it and/or throwing it away.
 	avFramePool *framePool
 
-	mimeHandler *MimeHandler
+	mimeHandler *mimeHandler
 
 	logger logging.Logger
 


### PR DESCRIPTION
## Description

This PR moves to using libAV for JPEG mime handling and streamlines the frame pipeline from decoding to API returns from Image.
- Removes RGB pixel conversion in decoder.
  - We now simply copy yuv420 bytes to the AvFrameWrapper in the pool. 
  - Moves AvFrameWrapper toImage helper to fill Ycbcr image.
- Replaces golang jpeg encoder with libav MJPEG codec.
  - Sets up an MJPEG encoder that will reinitiate on size changes.
- Makes the MJPEG decoder path more efficient by removing going to and from a go image.

## Tests
- basic tests:
  - h264 Image ✅ 
  - h264 passthrough ✅ 
  - h265 Image ✅ 
  - mjpeg Image ✅ 
- frame size changes while running ✅ 
- two concurrent clients polling Image ✅ 
- reconfigure stuff:
  - module reconfigure ✅ 
  - viam-server shutdown does not hang ✅ 
  - removing and adding module no hangs ✅ 

## Performance
- CPU Profiling
  - Noticing slightly less time spent in performance iteration (10-15%).
    - This is to be expected since we replaced a pixel conversion with a memory copy into the pool and removed going to a go image before encoding.
[cpu-profile-main-branch.txt](https://github.com/user-attachments/files/18414369/cpu-profile-main-branch.txt)
[cpu-profile-feature-branch.txt](https://github.com/user-attachments/files/18414393/cpu-profile-feature-branch.txt)

- Memory Profiling 
  - As expected, no appreciable diff in memory
[mem-profile-main-branch.txt](https://github.com/user-attachments/files/18414930/mem-profile-main-branch.txt)
[mem-profile-feature-branch.txt](https://github.com/user-attachments/files/18414450/mem-profile-feature-branch.txt)