### PR TITLE
[RSDK-9723] Fix mjpeg CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,10 +24,10 @@ jobs:
             viam_server_url: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-aarch64.AppImage
             docker_image: ghcr.io/viamrobotics/antique2:arm64-cache
         config:
-          - name: "h264"
-            codec: "libx264"
-          - name: "h265"
-            codec: "libx265"
+          # - name: "h264"
+          #   codec: "libx264"
+          # - name: "h265"
+          #   codec: "libx265"
           - name: "mjpeg"
             codec: "mjpeg"
             extra_ffmpeg_args: "-huffman 0"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,13 +24,16 @@ jobs:
             viam_server_url: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-aarch64.AppImage
             docker_image: ghcr.io/viamrobotics/antique2:arm64-cache
         config:
-          # - name: "h264"
-          #   codec: "libx264"
-          # - name: "h265"
-          #   codec: "libx265"
+          - name: "h264"
+            codec: "libx264"
+            pix_fmt: "yuv420p"
+          - name: "h265"
+            codec: "libx265"
+            pix_fmt: "yuv420p"
           - name: "mjpeg"
             codec: "mjpeg"
             extra_ffmpeg_args: "-huffman 0"
+            pix_fmt: "yuvj420p"
 
     runs-on: ${{ matrix.platform.runner }}
 
@@ -59,7 +62,7 @@ jobs:
       run: ./mediamtx &
       
     - name: Run fake RTSP camera
-      run: ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec ${{ matrix.config.codec }} ${{ matrix.config.extra_ffmpeg_args }} -pix_fmt yuv420p -f rtsp -rtsp_transport tcp rtsp://0.0.0.0:8554/live.stream &
+      run: ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec ${{ matrix.config.codec }} ${{ matrix.config.extra_ffmpeg_args }} -pix_fmt ${{ matrix.config.pix_fmt }} -f rtsp -rtsp_transport tcp rtsp://0.0.0.0:8554/live.stream &
       
     - name: Install viam-server
       run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,10 +28,9 @@ jobs:
             codec: "libx264"
           - name: "h265"
             codec: "libx265"
-          # RSDK-9723
-          # - name: "mjpeg"
-          #   codec: "mjpeg"
-          #   extra_ffmpeg_args: "-huffman 0"
+          - name: "mjpeg"
+            codec: "mjpeg"
+            extra_ffmpeg_args: "-huffman 0"
 
     runs-on: ${{ matrix.platform.runner }}
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9723

Noticed that `Non full-range YUV is non-standard` as per the error message attached by Nick on the Jira ticket

Changed requested pixel format from yuv420 to yuvj420 (full color range) for mjpeg and all CI successfully runs now