### PR TITLE
add empty cred

### DIFF
--- a/viamonvifdiscovery/service.go
+++ b/viamonvifdiscovery/service.go
@@ -20,6 +20,7 @@ import (
 var (
 	Model             = viamrtsp.Family.WithModel("onvif")
 	errNoCamerasFound = errors.New("no cameras found, ensure cameras are working or check credentials")
+	emptyCred         = device.Credentials{}
 )
 
 func init() {
@@ -65,7 +66,7 @@ func newDiscovery(_ context.Context, _ resource.Dependencies,
 	}
 	dis := &rtspDiscovery{
 		Named:       conf.ResourceName().AsNamed(),
-		Credentials: cfg.Credentials,
+		Credentials: append([]device.Credentials{emptyCred}, cfg.Credentials...),
 		logger:      logger,
 	}
 


### PR DESCRIPTION
I missed that the new discovery function still needs a credential to be passed in to run. by adding an empty credential it ensures that insecure cameras on the network are found