### PR TITLE
[RSDK-9833] - Add preference for TCP transport

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,6 +36,7 @@ jobs:
             codec: "mjpeg"
             extra_ffmpeg_args: "-huffman 0"
             pix_fmt: "yuvj420p"
+            transport: "tcp"
           - name: "mpeg4"
             codec: "mpeg4"
             pix_fmt: "yuv420p"
@@ -52,6 +53,10 @@ jobs:
             codec: "mjpeg"
             extra_ffmpeg_args: "-huffman 0"
             pix_fmt: "yuvj420p"
+            transport: "udp"
+          - name: "mpeg4"
+            codec: "mpeg4"
+            pix_fmt: "yuv420p"
             transport: "udp"
 
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,9 +27,11 @@ jobs:
           - name: "h264"
             codec: "libx264"
             pix_fmt: "yuv420p"
+            transport: "tcp"
           - name: "h265"
             codec: "libx265"
             pix_fmt: "yuv420p"
+            transport: "tcp"
           - name: "mjpeg"
             codec: "mjpeg"
             extra_ffmpeg_args: "-huffman 0"
@@ -37,6 +39,20 @@ jobs:
           - name: "mpeg4"
             codec: "mpeg4"
             pix_fmt: "yuv420p"
+            transport: "tcp"
+          - name: "h264"
+            codec: "libx264"
+            pix_fmt: "yuv420p"
+            transport: "udp"
+          - name: "h265"
+            codec: "libx265"
+            pix_fmt: "yuv420p"
+            transport: "udp"
+          - name: "mjpeg"
+            codec: "mjpeg"
+            extra_ffmpeg_args: "-huffman 0"
+            pix_fmt: "yuvj420p"
+            transport: "udp"
 
     runs-on: ${{ matrix.platform.runner }}
 
@@ -65,7 +81,7 @@ jobs:
       run: ./mediamtx &
       
     - name: Run fake RTSP camera
-      run: ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec ${{ matrix.config.codec }} ${{ matrix.config.extra_ffmpeg_args }} -pix_fmt ${{ matrix.config.pix_fmt }} -f rtsp -rtsp_transport tcp rtsp://0.0.0.0:8554/live.stream &
+      run: ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec ${{ matrix.config.codec }} ${{ matrix.config.extra_ffmpeg_args }} -pix_fmt ${{ matrix.config.pix_fmt }} -f rtsp -rtsp_transport ${{ matrix.config.transport }} rtsp://0.0.0.0:8554/live.stream &
       
     - name: Install viam-server
       run: |

--- a/rtsp.go
+++ b/rtsp.go
@@ -527,11 +527,8 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		rc.logger.Warn("no PPS found in H265 format")
 	}
 
-	res, err := rc.client.Setup(session.BaseURL, media, 0, 0)
+	_, err = rc.client.Setup(session.BaseURL, media, 0, 0)
 	if err != nil {
-		if res != nil {
-			return fmt.Errorf("status code when calling RTSP Setup on %s for H265: %w, status_code: %d", session.BaseURL, err, res.StatusCode)
-		}
 		return fmt.Errorf("when calling RTSP Setup on %s for H265: %w", session.BaseURL, err)
 	}
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -274,13 +274,12 @@ func (rc *rtspCamera) reconnectClientWithFallbackTransports(codecInfo videoCodec
 	// If all attempts fail, return the last error.
 	var lastErr error
 	for _, transport := range transports {
-		rc.logger.Info("attempting to reconnect with transport: ", transport.String())
 		if err := rc.reconnectClient(codecInfo, transport); err != nil {
 			rc.logger.Warnf("cannot reconnect to rtsp server using transport %s, err: %s", transport.String(), err.Error())
 			lastErr = err
 			continue
 		}
-		rc.logger.Infof("reconnected to rtsp server url: %s", rc.u)
+		rc.logger.Debugf("successfully reconnected to rtsp server url: %s", rc.u)
 		return nil
 	}
 	return fmt.Errorf("all attempts to reconnect to rtsp server failed: %w", lastErr)
@@ -288,7 +287,7 @@ func (rc *rtspCamera) reconnectClientWithFallbackTransports(codecInfo videoCodec
 
 // reconnectClient reconnects the RTSP client to the streaming server by closing the old one and starting a new one.
 func (rc *rtspCamera) reconnectClient(codecInfo videoCodec, transport *gortsplib.Transport) error {
-	rc.logger.Warnf("reconnectClient called with codec: %s", codecInfo)
+	rc.logger.Warnf("reconnectClient called with codec: %s and transport: %s", codecInfo, transport.String())
 
 	rc.closeConnection()
 


### PR DESCRIPTION
## Description

Currently, the default behavior of gortsplib is to first try udp and then fallback to tcp if it is not available. This is an issue because the parser is much more stable when using TCP transport.

This is a simple PR to wrap our `reconnectClient` flow with a retry mechanism to attempt the connection using TCP, UDP, and UDP-multicast in a priority order.

!!! Due to a quirk with how Setup's are handled in gortsplib we cannot simply retry Setup calls with specified transport so we must fully teardown and restart the connection flow for each attempt.


## Tests

### Manual Tests
Manual tested transport retries using mediamtx. 
We can specify available transports in the `mediamtx.yml` file and connect an appropriate fake RTSP feed using FFmpeg.
`protocols: [udp, multicast, tcp]`.
`ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec hevc -pix_fmt yuv420p -f rtsp -rtsp_transport <transport> rtsp://0.0.0.0:8554/live.stream`.
- udp ✅ 
- tcp ✅ 
- multicast (todo)
  - !!! even latest ffmpeg 7.1 does not support multicast.
- reconfigures ✅ 

### Automated Tests
- Added both "tcp" and "udp" transport integration tests. ✅ 
  - See succesful CI run [here](https://github.com/seanavery/viamrtsp/actions/runs/13017702730/job/36310843767).
  
  ## Profiling
  
  
![Screenshot 2025-01-29 at 1 06 26 PM](https://github.com/user-attachments/assets/01b4ac40-aebd-4e21-a022-53a1fc62b8be)

