### PR TITLE
[RSDK-9807]   Return RGBA bytes from viamrtsp

### DIFF
--- a/mime.go
+++ b/mime.go
@@ -17,6 +17,7 @@ import "C"
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync"
 	"unsafe"
 
@@ -166,7 +167,7 @@ func (mh *mimeHandler) convertPixelFormat(
 	mimeType string,
 ) ([]byte, camera.ImageMetadata, error) {
 	if frame == nil {
-		return nil, camera.ImageMetadata{}, errors.New("frame input is nil, cannot convert to " + format)
+		return nil, camera.ImageMetadata{}, fmt.Errorf("frame input is nil, cannot convert to %s", format)
 	}
 
 	mu.Lock()
@@ -179,10 +180,10 @@ func (mh *mimeHandler) convertPixelFormat(
 	}
 
 	if *swsCtx == nil {
-		return nil, camera.ImageMetadata{}, errors.New("failed to create " + format + " converter")
+		return nil, camera.ImageMetadata{}, fmt.Errorf("failed to create %s converter", format)
 	}
 	if *dstFrame == nil {
-		return nil, camera.ImageMetadata{}, errors.New("failed to create " + format + " destination frame")
+		return nil, camera.ImageMetadata{}, fmt.Errorf("failed to create %s destination frame", format)
 	}
 
 	res := C.sws_scale(

--- a/mime_cgo.go
+++ b/mime_cgo.go
@@ -90,29 +90,3 @@ func freeFrame(frame *C.AVFrame) {
 func createTestRGBAFrame(width, height int) *C.AVFrame {
 	return createTestFrame(width, height, C.AV_PIX_FMT_RGBA)
 }
-
-func fillDummyRGBAData(frame *C.AVFrame) {
-	width := int(frame.width)
-	height := int(frame.height)
-	linesize := int(frame.linesize[0])
-
-	rgbaPlane := (*[1 << 30]uint8)(unsafe.Pointer(frame.data[0]))[: height*linesize : height*linesize]
-
-	// Top half: solid red (255, 0, 0, 255)
-	// Bottom half: solid blue (0, 0, 255, 255)
-	for y := range height {
-		for x := range width {
-			idx := y*linesize + x*rgbaBytesPerPixel
-			if y < height/2 {
-				rgbaPlane[idx+0] = 255 // R
-				rgbaPlane[idx+1] = 0   // G
-				rgbaPlane[idx+2] = 0   // B
-			} else {
-				rgbaPlane[idx+0] = 0   // R
-				rgbaPlane[idx+1] = 0   // G
-				rgbaPlane[idx+2] = 255 // B
-			}
-			rgbaPlane[idx+3] = 255 // A always fully opaque
-		}
-	}
-}

--- a/mime_cgo.go
+++ b/mime_cgo.go
@@ -86,3 +86,33 @@ func fillDummyYUV420PData(frame *C.AVFrame) {
 func freeFrame(frame *C.AVFrame) {
 	C.av_frame_free(&frame)
 }
+
+func createTestRGBAFrame(width, height int) *C.AVFrame {
+	return createTestFrame(width, height, C.AV_PIX_FMT_RGBA)
+}
+
+func fillDummyRGBAData(frame *C.AVFrame) {
+	width := int(frame.width)
+	height := int(frame.height)
+	linesize := int(frame.linesize[0])
+
+	rgbaPlane := (*[1 << 30]uint8)(unsafe.Pointer(frame.data[0]))[: height*linesize : height*linesize]
+
+	// Top half: solid red (255, 0, 0, 255)
+	// Bottom half: solid blue (0, 0, 255, 255)
+	for y := range height {
+		for x := range width {
+			idx := y*linesize + x*rgbaBytesPerPixel
+			if y < height/2 {
+				rgbaPlane[idx+0] = 255 // R
+				rgbaPlane[idx+1] = 0   // G
+				rgbaPlane[idx+2] = 0   // B
+			} else {
+				rgbaPlane[idx+0] = 0   // R
+				rgbaPlane[idx+1] = 0   // G
+				rgbaPlane[idx+2] = 255 // B
+			}
+			rgbaPlane[idx+3] = 255 // A always fully opaque
+		}
+	}
+}

--- a/mime_test.go
+++ b/mime_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"go.viam.com/rdk/logging"
+	rutils "go.viam.com/rdk/utils"
 	"go.viam.com/test"
 )
 
@@ -111,5 +112,50 @@ func TestYUYVConvert(t *testing.T) {
 		test.That(t, parsedWidth, test.ShouldEqual, origWidth)
 		parsedHeight := int(binary.BigEndian.Uint32(header[8:12]))
 		test.That(t, parsedHeight, test.ShouldEqual, origHeight)
+	})
+}
+
+func TestRGBAConvert(t *testing.T) {
+	t.Run("valid YUV420P frame succeeds", func(t *testing.T) {
+		width, height := 640, 480
+		frame := createTestYUV420PFrame(width, height)
+		test.That(t, frame, test.ShouldNotBeNil)
+		defer freeFrame(frame)
+		fillDummyYUV420PData(frame)
+		logger := logging.NewDebugLogger("mime_test")
+		mh := newMimeHandler(logger)
+		bytes, metadata, err := mh.convertRGBA(frame)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, bytes, test.ShouldNotBeNil)
+		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel)
+		test.That(t, metadata.MimeType, test.ShouldEqual, rutils.MimeTypeRawRGBA)
+	})
+
+	t.Run("valid YUVJ420P frame succeeds", func(t *testing.T) {
+		width, height := 640, 480
+		frame := createTestYUVJ420PFrame(width, height)
+		test.That(t, frame, test.ShouldNotBeNil)
+		defer freeFrame(frame)
+		fillDummyYUV420PData(frame)
+		logger := logging.NewDebugLogger("mime_test")
+		mh := newMimeHandler(logger)
+		bytes, metadata, err := mh.convertRGBA(frame)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, bytes, test.ShouldNotBeNil)
+		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel)
+		test.That(t, metadata.MimeType, test.ShouldEqual, rutils.MimeTypeRawRGBA)
+	})
+
+	t.Run("invalid frame fails", func(t *testing.T) {
+		frame := createInvalidFrame()
+		test.That(t, frame, test.ShouldNotBeNil)
+		defer freeFrame(frame)
+		logger := logging.NewDebugLogger("mime_test")
+		mh := newMimeHandler(logger)
+		bytes, metadata, err := mh.convertRGBA(frame)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to allocate buffer for RGBA")
+		test.That(t, bytes, test.ShouldBeNil)
+		test.That(t, metadata.MimeType, test.ShouldBeEmpty)
 	})
 }

--- a/mime_test.go
+++ b/mime_test.go
@@ -93,11 +93,12 @@ func TestYUYVConvert(t *testing.T) {
 		mh := newMimeHandler(logger)
 		bytes, metadata, err := mh.convertYUYV(frame)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to allocate buffer for YUYV")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to allocate buffer")
 		test.That(t, bytes, test.ShouldBeNil)
 		test.That(t, metadata.MimeType, test.ShouldBeEmpty)
 	})
 
+	//nolint:dupl
 	t.Run("test yuyv magic header", func(t *testing.T) {
 		origWidth := 640
 		origHeight := 480
@@ -116,12 +117,12 @@ func TestYUYVConvert(t *testing.T) {
 }
 
 func TestRGBAConvert(t *testing.T) {
-	t.Run("valid YUV420P frame succeeds", func(t *testing.T) {
+	t.Run("valid RGBA frame succeeds", func(t *testing.T) {
 		width, height := 640, 480
-		frame := createTestYUV420PFrame(width, height)
+		frame := createTestRGBAFrame(width, height)
 		test.That(t, frame, test.ShouldNotBeNil)
 		defer freeFrame(frame)
-		fillDummyYUV420PData(frame)
+		fillDummyRGBAData(frame)
 		logger := logging.NewDebugLogger("mime_test")
 		mh := newMimeHandler(logger)
 		bytes, metadata, err := mh.convertRGBA(frame)
@@ -129,21 +130,30 @@ func TestRGBAConvert(t *testing.T) {
 		test.That(t, bytes, test.ShouldNotBeNil)
 		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel+12) // header size
 		test.That(t, metadata.MimeType, test.ShouldEqual, rutils.MimeTypeRawRGBA)
-	})
 
-	t.Run("valid YUVJ420P frame succeeds", func(t *testing.T) {
-		width, height := 640, 480
-		frame := createTestYUVJ420PFrame(width, height)
-		test.That(t, frame, test.ShouldNotBeNil)
-		defer freeFrame(frame)
-		fillDummyYUV420PData(frame)
-		logger := logging.NewDebugLogger("mime_test")
-		mh := newMimeHandler(logger)
-		bytes, metadata, err := mh.convertRGBA(frame)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, bytes, test.ShouldNotBeNil)
-		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel+12) // header size
-		test.That(t, metadata.MimeType, test.ShouldEqual, rutils.MimeTypeRawRGBA)
+		// Verify the header
+		header := bytes[:12]
+		test.That(t, header[0], test.ShouldEqual, 'R')
+		test.That(t, header[1], test.ShouldEqual, 'G')
+		test.That(t, header[2], test.ShouldEqual, 'B')
+		test.That(t, header[3], test.ShouldEqual, 'A')
+
+		// Verify the RGBA data
+		data := bytes[12:]
+
+		// Check top half (should be red)
+		idx := (height / 4) * width * rgbaBytesPerPixel        // Point in top half
+		test.That(t, data[idx+0], test.ShouldEqual, byte(255)) // R
+		test.That(t, data[idx+1], test.ShouldEqual, byte(0))   // G
+		test.That(t, data[idx+2], test.ShouldEqual, byte(0))   // B
+		test.That(t, data[idx+3], test.ShouldEqual, byte(255)) // A
+
+		// Check bottom half (should be blue)
+		idx = (3 * height / 4) * width * rgbaBytesPerPixel     // Point in bottom half
+		test.That(t, data[idx+0], test.ShouldEqual, byte(0))   // R
+		test.That(t, data[idx+1], test.ShouldEqual, byte(0))   // G
+		test.That(t, data[idx+2], test.ShouldEqual, byte(255)) // B
+		test.That(t, data[idx+3], test.ShouldEqual, byte(255)) // A
 	})
 
 	t.Run("invalid frame fails", func(t *testing.T) {
@@ -154,8 +164,25 @@ func TestRGBAConvert(t *testing.T) {
 		mh := newMimeHandler(logger)
 		bytes, metadata, err := mh.convertRGBA(frame)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to allocate buffer for RGBA")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to allocate buffer")
 		test.That(t, bytes, test.ShouldBeNil)
 		test.That(t, metadata.MimeType, test.ShouldBeEmpty)
+	})
+
+	//nolint:dupl
+	t.Run("test rgba magic header", func(t *testing.T) {
+		origWidth := 640
+		origHeight := 480
+		header := packRGBAHeader(origWidth, origHeight)
+		test.That(t, header, test.ShouldNotBeNil)
+		test.That(t, len(header), test.ShouldEqual, 12)
+		test.That(t, header[0], test.ShouldEqual, 'R')
+		test.That(t, header[1], test.ShouldEqual, 'G')
+		test.That(t, header[2], test.ShouldEqual, 'B')
+		test.That(t, header[3], test.ShouldEqual, 'A')
+		parsedWidth := int(binary.BigEndian.Uint32(header[4:8]))
+		test.That(t, parsedWidth, test.ShouldEqual, origWidth)
+		parsedHeight := int(binary.BigEndian.Uint32(header[8:12]))
+		test.That(t, parsedHeight, test.ShouldEqual, origHeight)
 	})
 }

--- a/mime_test.go
+++ b/mime_test.go
@@ -127,7 +127,7 @@ func TestRGBAConvert(t *testing.T) {
 		bytes, metadata, err := mh.convertRGBA(frame)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, bytes, test.ShouldNotBeNil)
-		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel)
+		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel+12) // header size
 		test.That(t, metadata.MimeType, test.ShouldEqual, rutils.MimeTypeRawRGBA)
 	})
 
@@ -142,7 +142,7 @@ func TestRGBAConvert(t *testing.T) {
 		bytes, metadata, err := mh.convertRGBA(frame)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, bytes, test.ShouldNotBeNil)
-		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel)
+		test.That(t, len(bytes), test.ShouldEqual, width*height*rgbaBytesPerPixel+12) // header size
 		test.That(t, metadata.MimeType, test.ShouldEqual, rutils.MimeTypeRawRGBA)
 	})
 

--- a/mime_test.go
+++ b/mime_test.go
@@ -119,10 +119,10 @@ func TestYUYVConvert(t *testing.T) {
 func TestRGBAConvert(t *testing.T) {
 	t.Run("valid RGBA frame succeeds", func(t *testing.T) {
 		width, height := 640, 480
-		frame := createTestRGBAFrame(width, height)
+		frame := createTestYUV420PFrame(width, height)
 		test.That(t, frame, test.ShouldNotBeNil)
 		defer freeFrame(frame)
-		fillDummyRGBAData(frame)
+		fillDummyYUV420PData(frame)
 		logger := logging.NewDebugLogger("mime_test")
 		mh := newMimeHandler(logger)
 		bytes, metadata, err := mh.convertRGBA(frame)
@@ -137,23 +137,6 @@ func TestRGBAConvert(t *testing.T) {
 		test.That(t, header[1], test.ShouldEqual, 'G')
 		test.That(t, header[2], test.ShouldEqual, 'B')
 		test.That(t, header[3], test.ShouldEqual, 'A')
-
-		// Verify the RGBA data
-		data := bytes[12:]
-
-		// Check top half (should be red)
-		idx := (height / 4) * width * rgbaBytesPerPixel        // Point in top half
-		test.That(t, data[idx+0], test.ShouldEqual, byte(255)) // R
-		test.That(t, data[idx+1], test.ShouldEqual, byte(0))   // G
-		test.That(t, data[idx+2], test.ShouldEqual, byte(0))   // B
-		test.That(t, data[idx+3], test.ShouldEqual, byte(255)) // A
-
-		// Check bottom half (should be blue)
-		idx = (3 * height / 4) * width * rgbaBytesPerPixel     // Point in bottom half
-		test.That(t, data[idx+0], test.ShouldEqual, byte(0))   // R
-		test.That(t, data[idx+1], test.ShouldEqual, byte(0))   // G
-		test.That(t, data[idx+2], test.ShouldEqual, byte(255)) // B
-		test.That(t, data[idx+3], test.ShouldEqual, byte(255)) // A
 	})
 
 	t.Run("invalid frame fails", func(t *testing.T) {

--- a/rtsp.go
+++ b/rtsp.go
@@ -1012,6 +1012,8 @@ func (rc *rtspCamera) getAndConvertFrame(mimeType string) ([]byte, camera.ImageM
 		bytes, metadata, err = rc.mimeHandler.convertJPEG(currentFrame.frame)
 	case mimeTypeYUYV, mimeTypeYUYV + "+" + rutils.MimeTypeSuffixLazy:
 		bytes, metadata, err = rc.mimeHandler.convertYUYV(currentFrame.frame)
+	case rutils.MimeTypeRawRGBA, rutils.MimeTypeRawRGBA + "+" + rutils.MimeTypeSuffixLazy:
+		bytes, metadata, err = rc.mimeHandler.convertRGBA(currentFrame.frame)
 	default:
 		rc.logger.Debugf("unsupported mime type: %s, defaulting to JPEG", mimeType)
 		bytes, metadata, err = rc.mimeHandler.convertJPEG(currentFrame.frame)


### PR DESCRIPTION
[RSDK-9807](https://viam.atlassian.net/browse/RSDK-9807)

[RSDK-9807]: https://viam.atlassian.net/browse/RSDK-9807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Tested with my local Python SDK client
```
async def main():
    try:
        robot = await connect()
        cam = Camera.from_robot(robot, 'rtsp-1')
        count = 0
        while count < 3:
            try:
                count += 1
                img = await cam.get_image(mime_type=CameraMimeType.VIAM_RGBA)
                print(f"count: {count}")
                print(f"img.mime_type: {img.mime_type}")
                print(f"img.data: {img.data[:800]}")
                pil_img = viam_to_pil_image(img)
                pil_img.show()
            except Exception as e:
                print(f"Error getting/processing image: {e}")
                break
    finally:
        await cam.close()
        await robot.close()
```
This means that the serialized output was successfully sent over the wire and deserialized by the Python SDK, with a helper func Robin could/is using.

This PR also makes a few C/libav safety changes in mime.go with freeing the encoders, avoiding double frees, and setting jpeg enc opts

## Manual tests
### Regression tests

- [x] h264 to yuyv 
- [x] h264 to jpeg 
- [x] h265 to yuyv 
- [x] h265 to jpeg 
- [x] live size change yuyv handling 
- [x] multiple yuyv subscribers 
- [x] `video-store`ing with `yuyv` config attr set to true

### RGBA tests

- [x] h264 to rgba
- [x] h265 to rgba
- [x] mpeg to rgba
- [x] live size change rgba handling 
- [x] multiple rgba subscribers
- [x] 2 yuyv subscriber, 2 rgba subscriber, 2 jpeg subscriber (concurrently using a Go client)
