### PR TITLE
[RSDK-9834] - Pack NALUs in h265 decode flow

### DIFF
--- a/rtsp.go
+++ b/rtsp.go
@@ -513,13 +513,18 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		// If the AU has more than one NALU, compact them into a single payload with NALUs seperated
 		// in AnnexB format. This is necessary because the H.265 decoder expects all NALUs for a frame
 		// to be in a single payload rather than chunked across multiple decode calls.
-		var packed []byte
+		packed := []byte{}
 		for i, nalu := range au {
 			// Add start code prefix to all NALUs except the first one.
 			if i != 0 {
 				packed = append(packed, H2645StartCode()...)
 			}
 			packed = append(packed, nalu...)
+		}
+
+		if len(packed) == 0 {
+			rc.logger.Warn("no NALUs found in H265 AU skipping packet")
+			return
 		}
 
 		frame, err := rc.rawDecoder.decode(packed)

--- a/rtsp.go
+++ b/rtsp.go
@@ -523,7 +523,7 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		}
 
 		if len(packed) == 0 {
-			rc.logger.Warn("no NALUs found in H265 AU skipping packet")
+			rc.logger.Warn("no NALUs found in H265 AU, skipping packet")
 			return
 		}
 


### PR DESCRIPTION
## Description

If we get an inter-frame (TRAIL_N or other) that is spread across multiple NALUs, which happens with large frame sizes, the decoder runs into issues since it is expecting to send and receive payloads on frame boundaries. 

This PR simply always packs the AU into a single packed payload. This ensures our decoder is able to receive a frame on the other end.

Confirmed this works for inter-frames (TRAIL_N) as well as key frame sets (VPS, SPS, PPS, IDR_W_RADL). In other words, it is ok to pack no matter what.

## Test
- steves 4k cam ✅ 
- other random office cams ✅ 