### PR TITLE
[RSDK-9920] - add lazy_decode

### DIFF
--- a/rtsp.go
+++ b/rtsp.go
@@ -384,7 +384,7 @@ func (rc *rtspCamera) consumeAU() {
 	defer rc.auMu.Unlock()
 	if len(rc.au) > 0 {
 		rc.storeH264Frame(rc.au)
-		rc.au = [][]byte{}
+		rc.au = nil
 	}
 }
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -162,8 +162,8 @@ type rtspCamera struct {
 	resource.AlwaysRebuild
 	model resource.Model
 	gostream.VideoReader
-	u             *base.URL
-	lazyDecodeRTP bool
+	u          *base.URL
+	lazyDecode bool
 
 	closeMu sync.RWMutex
 
@@ -457,7 +457,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 			return
 		}
 
-		if rc.lazyDecodeRTP {
+		if rc.lazyDecode {
 			if h264.IDRPresent(au) {
 				rc.resetAU(au)
 			} else {
@@ -525,7 +525,7 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		rc.logger.Warn("rtp_passthrough is only supported for H264 codec. rtp_passthrough features disabled due to H265 RTSP track")
 	}
 
-	if rc.lazyDecodeRTP {
+	if rc.lazyDecode {
 		rc.logger.Warn("lazy_decode is currently only supported for H264 codec. lazy_decode features disabled due to H265 RTSP track")
 	}
 	var f *format.H265
@@ -633,7 +633,7 @@ func (rc *rtspCamera) initMJPEG(session *description.Session) error {
 	if rc.rtpPassthrough {
 		rc.logger.Warn("rtp_passthrough is only supported for H264 codec. rtp_passthrough features disabled due to MJPEG RTSP track")
 	}
-	if rc.lazyDecodeRTP {
+	if rc.lazyDecode {
 		rc.logger.Warn("lazy_decode is currently only supported for H264 codec. lazy_decode features disabled due to MJPEG RTSP track")
 	}
 	var f *format.MJPEG
@@ -674,7 +674,7 @@ func (rc *rtspCamera) initMPEG4(session *description.Session) error {
 		rc.logger.Warn("rtp_passthrough is only supported for H264 codec. rtp_passthrough features disabled due to MPEG4 RTSP track")
 	}
 
-	if rc.lazyDecodeRTP {
+	if rc.lazyDecode {
 		rc.logger.Warn("lazy_decode is currently only supported for H264 codec. lazy_decode features disabled due to MPEG4 RTSP track")
 	}
 
@@ -886,7 +886,7 @@ func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 	rtpPassthroughCtx, rtpPassthroughCancelCauseFn := context.WithCancelCause(context.Background())
 	rc := &rtspCamera{
 		model:                       conf.Model,
-		lazyDecodeRTP:               newConf.LazyDecode,
+		lazyDecode:                  newConf.LazyDecode,
 		u:                           u,
 		name:                        conf.ResourceName(),
 		rtpPassthrough:              rtpPassthrough,

--- a/rtsp.go
+++ b/rtsp.go
@@ -106,7 +106,7 @@ func init() {
 type Config struct {
 	Address        string               `json:"rtsp_address"`
 	RTPPassthrough *bool                `json:"rtp_passthrough"`
-	LazyDecode     bool                 `json:"lazy_decode"`
+	LazyDecode     bool                 `json:"lazy_decode,omitempty"`
 	Query          viamupnp.DeviceQuery `json:"query"`
 }
 


### PR DESCRIPTION
### Changes:

https://viam.atlassian.net/browse/RSDK-9920

1. Add new config parameter: `lazy_decode: bool`, default: false
2. Only applies if codec is h264. If set and codec is anything else, log a warning at startup.
3. If set to true, accumulate the NALUs (h264 messages) since the last IDR. Only compute an image from those NALUs when camera.Image is called.

### Performance Impact:

**Hardware: Pi 5:**

> Resolution: 2304*1296 (larger than 1080p)
> Frame Rate (FPS): 25
> Max Bitrate (Kbps): 4096
> I-frame Interval: 2x (about every 2 seconds)
> 

**Baseline `lazy_decode: false` or unset:** 
1. no callers: htop reports ~35% cpu 
2. with gostream calling camera.Image as fast as it can:  htop reports ~50% cpu, each request takes ~35 ms

**`lazy_decode: true`**
1. no callers: htop reports ~2% cpu 
2. with gostream calling camera.Image as fast as it can:  htop reports ~50% cpu, each request takes 100-500 ms, depending on how frequently camera.Image is called. When called more frequently, fewer NALUs need to be processed and the image can be computed and returned faster. 

Here is a video of the experience of each config option.
1. first is with rtp_passthrough: true (best and the default)
2. second is with  rtp_passthrough: false, lazy_decode: false
3. third is with  rtp_passthrough: false, lazy_decode: true


https://github.com/user-attachments/assets/975d3d0d-442d-4a3f-ba5c-456b54861c74

