### PR TITLE
RSDK-9920-add-h265-lazy-decode

### DIFF
--- a/rtsp.go
+++ b/rtsp.go
@@ -259,7 +259,7 @@ func (rc *rtspCamera) closeConnection() {
 		rc.client.Close()
 		rc.client = nil
 	}
-	rc.resetLazyAU(nil)
+	rc.resetLazyAU([][]byte{})
 	rc.currentCodec.Store(0)
 	if rc.rawDecoder != nil {
 		rc.rawDecoder.close()

--- a/rtsp.go
+++ b/rtsp.go
@@ -400,6 +400,8 @@ func (rc *rtspCamera) consumeAU() {
 			rc.storeH264Frame(rc.au)
 		case H265:
 			for _, au := range rc.au {
+				// h265 AUs are already packed into a single frame
+				// before they were added to rc.au
 				rc.storeH265Frame(au)
 			}
 		default:

--- a/rtsp.go
+++ b/rtsp.go
@@ -608,8 +608,6 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		au, err := rtpDec.Decode(pkt)
 		if err != nil {
 			if !errors.Is(err, rtph265.ErrNonStartingPacketAndNoPrevious) && !errors.Is(err, rtph265.ErrMorePacketsNeeded) {
-				// This error is created with `github.com/pkg/errors`. Explicitly call `Error()` to
-				// avoid logging the stacktrace.
 				rc.logger.Debugw("error decoding(1) h265 rstp stream", "err", err.Error())
 			}
 			return
@@ -659,8 +657,6 @@ func (rc *rtspCamera) storeH265Frame(nalu []byte) {
 
 	frame, err := rc.rawDecoder.decode(nalu)
 	if err != nil {
-		// This error is created with `github.com/pkg/errors`. Explicitly call `Error()` to
-		// avoid logging the stacktrace.
 		rc.logger.Debugw("error decoding(2) h265 rtsp stream", "err", err.Error())
 		return
 	}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-9920)
Follow up from https://github.com/viam-modules/viamrtsp/pull/85

Manual Testing:
Camera: [Marquis IPC-XD400](https://marquis-store.com/products/hikvision-uniview-compatible-ip-turret-camera-4mp)

1. m2 macbook air 2022 + pi 5 + orin nx:

> codecs: H264, H265, H265+
> resolution: 2560x1440
> fps: 20
> bit rate: 3500(kb/s)


4k Camera[RLC-823A 16X](https://reolink.com/product/rlc-823a-16x/?srsltid=AfmBOoqr_vec3Dj5v1v33TSjdm1hzuaoAeIFoT7sIfE16IV8Nbb2eRi8)

> codecs: H265
> resolution: 3840*2160
> fps: 25
> bit rate: 4096 (kb/s)