### PR TITLE
Rsdk 9919 move video store logic into viamrtsp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,22 +65,13 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-encoder=libx264
 
 # Add linker flag -checklinkname=0 for anet https://github.com/wlynxg/anet?tab=readme-ov-file#how-to-build-with-go-1230-or-later.
-# GO_LDFLAGS := -ldflags="-checklinkname=0 "
-# CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib /usr/lib/aarch64-linux-gnu/libx264.a"
-# CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib -l:libx264.a"
-# CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib libx264.a"
+GO_LDFLAGS := -ldflags="-checklinkname=0 "
 CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -lswscale -lz
+# TODO(seanp): Make sure this works on our CI runners.
 ifeq ($(SOURCE_OS),linux)
 	CGO_LDFLAGS += -l:libx264.a
 endif
-# ifeq ($(SOURCE_OS),linux)
-# 	CGO_LDFLAGS += /usr/lib/aarch64-linux-gnu/libx264.a
-# endif
-# CGO_LDFLAGS += -l:libx264.a
-# CGO_LDFLAGS += /usr/lib/aarch64-linux-gnu/libx264.a
-# CGO_LDFLAGS += -L/usr/lib/aarch64-linux-gnu -lx264
 CGO_CFLAGS := -I$(FFMPEG_BUILD)/include
-export PKG_CONFIG_PATH=$(FFMPEG_BUILD)/lib/pkgconfig
 
 # If we are building for android, we need to set the correct flags
 # and toolchain paths for FFMPEG and go binary cross-compilation.

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,36 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-encoder=mpeg4 \
                --enable-network \
                --enable-parser=h264 \
-               --enable-parser=hevc
+               --enable-parser=hevc \
+               --enable-muxer=segment \
+               --enable-muxer=mp4 \
+               --enable-demuxer=segment \
+               --enable-demuxer=concat \
+               --enable-demuxer=mov \
+               --enable-demuxer=mp4 \
+               --enable-protocol=file \
+               --enable-protocol=concat \
+               --enable-protocol=crypto \
+               --enable-bsf=h264_mp4toannexb \
+               --enable-libx264 \
+               --enable-gpl \
+               --enable-encoder=libx264
 
 # Add linker flag -checklinkname=0 for anet https://github.com/wlynxg/anet?tab=readme-ov-file#how-to-build-with-go-1230-or-later.
-GO_LDFLAGS := -ldflags="-checklinkname=0"
-CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib
+# GO_LDFLAGS := -ldflags="-checklinkname=0 "
+# CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib /usr/lib/aarch64-linux-gnu/libx264.a"
+# CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib -l:libx264.a"
+# CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib libx264.a"
+CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -lswscale -lz
+ifeq ($(SOURCE_OS),linux)
+	CGO_LDFLAGS += -l:libx264.a
+endif
+# ifeq ($(SOURCE_OS),linux)
+# 	CGO_LDFLAGS += /usr/lib/aarch64-linux-gnu/libx264.a
+# endif
+# CGO_LDFLAGS += -l:libx264.a
+# CGO_LDFLAGS += /usr/lib/aarch64-linux-gnu/libx264.a
+# CGO_LDFLAGS += -L/usr/lib/aarch64-linux-gnu -lx264
 CGO_CFLAGS := -I$(FFMPEG_BUILD)/include
 export PKG_CONFIG_PATH=$(FFMPEG_BUILD)/lib/pkgconfig
 
@@ -89,7 +114,7 @@ all: $(BIN_OUTPUT_PATH)/viamrtsp $(BIN_OUTPUT_PATH)/discovery
 
 # We set GOOS, GOARCH, GO_TAGS, and GO_LDFLAGS to support cross-compilation for android targets.
 $(BIN_OUTPUT_PATH)/viamrtsp: build-ffmpeg *.go cmd/module/*.go
-	CGO_LDFLAGS=$(CGO_LDFLAGS) \
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" \
 	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) $(GO_LDFLAGS) -o $(BIN_OUTPUT_PATH)/viamrtsp cmd/module/cmd.go
 
 $(BIN_OUTPUT_PATH)/discovery: build-ffmpeg *.go cmd/discovery/*.go

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ ifeq ($(SOURCE_OS),linux)
 	CGO_LDFLAGS += -l:libx264.a
 endif
 CGO_CFLAGS := -I$(FFMPEG_BUILD)/include
+export PKG_CONFIG_PATH=$(FFMPEG_BUILD)/lib/pkgconfig
 
 # If we are building for android, we need to set the correct flags
 # and toolchain paths for FFMPEG and go binary cross-compilation.

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(BIN_OUTPUT_PATH)/viamrtsp: build-ffmpeg *.go cmd/module/*.go
 	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) $(GO_LDFLAGS) -o $(BIN_OUTPUT_PATH)/viamrtsp cmd/module/cmd.go
 
 $(BIN_OUTPUT_PATH)/discovery: build-ffmpeg *.go cmd/discovery/*.go
-	CGO_LDFLAGS=$(CGO_LDFLAGS) \
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" \
 	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) $(GO_LDFLAGS) -o $(BIN_OUTPUT_PATH)/discovery cmd/discovery/cmd.go
 
 tool-install:

--- a/decoder.go
+++ b/decoder.go
@@ -1,7 +1,6 @@
 package viamrtsp
 
 /*
-#cgo pkg-config: libavcodec libavutil libswscale
 #include <libavcodec/avcodec.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/error.h>

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.1.118
 	golang.org/x/net v0.30.0
+	github.com/viam-modules/video-store v0.0.3
+
 )
 
 require (
@@ -97,7 +99,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/firefart/nonamedreturns v1.0.5 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fullstorydev/grpcurl v1.8.6 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/gen2brain/malgo v0.11.21 // indirect
@@ -339,3 +341,5 @@ require (
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace github.com/viam-modules/video-store => ./video-store/video-store-review

--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,12 @@ require (
 	github.com/pion/rtp v1.8.7
 	github.com/rhysd/actionlint v1.6.27
 	github.com/stretchr/testify v1.9.0
+	github.com/viam-modules/video-store v0.0.3
 	go.uber.org/zap v1.27.0
 	go.viam.com/rdk v0.57.1-0.20250108163155-2071720cd8d3
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.1.118
 	golang.org/x/net v0.30.0
-	github.com/viam-modules/video-store v0.0.3
 
 )
 
@@ -342,4 +342,4 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/viam-modules/video-store => ./video-store/video-store-review
+replace github.com/viam-modules/video-store => ./video-store

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fullstorydev/grpcurl v1.8.6 h1:WylAwnPauJIofYSHqqMTC1eEfUIzqzevXyogBxnQquo=
 github.com/fullstorydev/grpcurl v1.8.6/go.mod h1:WhP7fRQdhxz2TkL97u+TCb505sxfH78W1usyoB3tepw=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
@@ -1564,7 +1564,6 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mime.go
+++ b/mime.go
@@ -1,7 +1,6 @@
 package viamrtsp
 
 /*
-#cgo pkg-config: libavutil libavcodec libswscale
 #include <libavcodec/avcodec.h>
 #include <libavutil/error.h>
 #include <libavutil/opt.h>

--- a/rtsp.go
+++ b/rtsp.go
@@ -504,7 +504,8 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 			packed = append(packed, lengthBytes...)
 			packed = append(packed, nalu...)
 		}
-		err = rc.rawSegmenter.WritePacket(packed, int64pts)
+		isIDR := h264.IDRPresent(au)
+		err = rc.rawSegmenter.WritePacket(packed, int64pts, isIDR)
 		if err != nil {
 			rc.logger.Errorf("error writing packet to segmenter: %s", err)
 		}

--- a/rtsp.go
+++ b/rtsp.go
@@ -212,6 +212,7 @@ func (rc *rtspCamera) Close(_ context.Context) error {
 	rc.closeConnection()
 	rc.avFramePool.close()
 	rc.mimeHandler.close()
+	rc.rawSegmenter.Close()
 	return nil
 }
 
@@ -477,11 +478,11 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 				return
 			}
 		}
-		// Pack AU into a single payload with NALUs seperated in AVC format.
+		// Pack AU into a single payload with NALUs separated in AVC format.
 		packed := []byte{}
 		for _, nalu := range au {
 			if len(nalu) == 0 {
-				rc.logger.Warn("segmenter found empty NALU found in H264 AU, skipping NALU")
+				rc.logger.Warn("segmenter found empty NALU in H264 AU, skipping NALU")
 				continue
 			}
 			// Skip in-band parameter sets as they are already provided in the codec context during

--- a/rtsp.go
+++ b/rtsp.go
@@ -917,12 +917,10 @@ func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 		rtpPassthrough = *newConf.RTPPassthrough
 	}
 
-	logger.Info("about to create raw segmenter")
 	rawSegmenter, err := videostore.NewRawSegmenter(logger, "/tmp/testing-raw-segmenter")
 	if err != nil {
 		logger.Errorf("error creating raw segmenter: %s", err.Error())
 	}
-	logger.Info("created raw segmenter")
 
 	rtpPassthroughCtx, rtpPassthroughCancelCauseFn := context.WithCancelCause(context.Background())
 	rc := &rtspCamera{

--- a/rtsp.go
+++ b/rtsp.go
@@ -2,7 +2,6 @@
 package viamrtsp
 
 /*
-#cgo pkg-config: libavutil libavcodec libavformat libswscale
 #include <libavcodec/avcodec.h>
 */
 import "C"


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-9919)

Derived from: https://github.com/viam-modules/viamrtsp/pull/87

## Description

This PR allows for an efficient video storage path in the viamrtsp module by passing through encoded RTSP feed directly into a segmenter.

> !!! Relies on changes in video-store repo. See PR [here](https://github.com/viam-modules/video-store/pull/37).

## Todo:
- [x] Working build with video-store as a library
- [x] Get playable video from h264 feed 
- [x] Split clips by keyframe 
- [ ] Add config attribute for video storage
- [ ] Get playable video from h265 feed
- [ ] Add hooks for do_command interface
  - Figure out how this plays with concater and deleter functionality inside of video-store