### PR TITLE
RSDK-9919-move-video-store-logic-into-viamrtsp2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,20 @@ $(FFMPEG_VERSION_PLATFORM):
 	git clone https://github.com/FFmpeg/FFmpeg.git --depth 1 --branch $(FFMPEG_TAG) $(FFMPEG_VERSION_PLATFORM)
 
 $(FFMPEG_BUILD): $(FFMPEG_VERSION_PLATFORM)
+# Only need nasm to build assembly kernels for amd64 targets.
+ifeq ($(SOURCE_OS),linux)
+ifeq ($(shell dpkg -l | grep -w x264 > /dev/null; echo $$?), 1)
+	sudo apt update && sudo apt install -y libx264-dev
+endif
+ifeq ($(SOURCE_ARCH),amd64)
+	which nasm || (sudo apt update && sudo apt install -y nasm)
+endif
+endif
+ifeq ($(SOURCE_OS),darwin)
+ifeq ($(shell brew list | grep -w x264 > /dev/null; echo $$?), 1)
+	brew update && brew install x264
+endif
+endif
 	cd $(FFMPEG_VERSION_PLATFORM) && ./configure $(FFMPEG_OPTS) && $(MAKE) -j$(NPROC) && $(MAKE) install
 
 build-ffmpeg: $(NDK_ROOT)

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ lint: gofmt tool-install build-ffmpeg
 	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
 test: build-ffmpeg
-	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go test -race -v ./...
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -race -v ./...
 
 profile-cpu:
 	go test -v -cpuprofile cpu.prof -run "^TestRTSPCameraPerformance$$" -bench github.com/viam-modules/viamrtsp

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
 
 # Add linker flag -checklinkname=0 for anet https://github.com/wlynxg/anet?tab=readme-ov-file#how-to-build-with-go-1230-or-later.
 PKG_CONFIG_PATH = $(FFMPEG_BUILD)/lib/pkgconfig
-CGO_CFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(FFMPEG_LIBS)) -I$(BUILD_DIR)
+CGO_CFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(FFMPEG_LIBS))
 ifeq ($(SOURCE_OS),linux)
 	SUBST = -l:libx264.a
 endif
@@ -118,10 +118,17 @@ all: $(BIN_OUTPUT_PATH)/viamrtsp $(BIN_OUTPUT_PATH)/discovery
 
 # We set GOOS, GOARCH, GO_TAGS, and GO_LDFLAGS to support cross-compilation for android targets.
 $(BIN_OUTPUT_PATH)/viamrtsp: build-ffmpeg *.go cmd/module/*.go
-	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) $(GO_LDFLAGS) -ldflags="-checklinkname=0" -o $(BIN_OUTPUT_PATH)/viamrtsp cmd/module/cmd.go
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	CGO_CFLAGS="$(CGO_CFLAGS)" \
+	GOOS=$(TARGET_OS) \
+	GOARCH=$(TARGET_ARCH) \
+	go build $(GO_TAGS) -ldflags="-checklinkname=0" -o $(BIN_OUTPUT_PATH)/viamrtsp cmd/module/cmd.go
 
 $(BIN_OUTPUT_PATH)/discovery: build-ffmpeg *.go cmd/discovery/*.go
-	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) $(GO_LDFLAGS) -ldflags="-checklinkname=0"-o $(BIN_OUTPUT_PATH)/discovery cmd/discovery/cmd.go
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	CGO_CFLAGS="$(CGO_CFLAGS)" \
+	GOOS=$(TARGET_OS) \
+	GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) -ldflags="-checklinkname=0" -o $(BIN_OUTPUT_PATH)/discovery cmd/discovery/cmd.go
 
 tool-install:
 	GOBIN=`pwd`/$(TOOL_BIN) go install \

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,7 @@ gofmt:
 
 lint: gofmt tool-install build-ffmpeg
 	go mod tidy
-	export pkgs="`go list -f '{{.Dir}}' ./...`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
-	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
+	CGO_CFLAGS=$(CGO_CFLAGS) GOFLAGS=$(GOFLAGS) $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml --timeout=2m
 
 test: build-ffmpeg
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -ldflags="-checklinkname=0" -race -v ./...

--- a/decoder.go
+++ b/decoder.go
@@ -225,6 +225,10 @@ func SetLibAVLogLevelFatal() {
 	C.av_log_set_level(C.AV_LOG_FATAL)
 }
 
+func SetLibAVLogLevelDebug() {
+	C.av_log_set_level(C.AV_LOG_DEBUG)
+}
+
 // newDecoder creates a new decoder for the given codec, including any extra configuration data.
 func newDecoder(codecID C.enum_AVCodecID, avFramePool *framePool, logger logging.Logger, extraData []byte) (*decoder, error) {
 	codec := C.avcodec_find_decoder(codecID)

--- a/decoder.go
+++ b/decoder.go
@@ -1,7 +1,6 @@
 package viamrtsp
 
 /*
-#cgo pkg-config: libavcodec libavutil libswscale
 #include <libavcodec/avcodec.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/error.h>

--- a/decoder.go
+++ b/decoder.go
@@ -225,6 +225,7 @@ func SetLibAVLogLevelFatal() {
 	C.av_log_set_level(C.AV_LOG_FATAL)
 }
 
+// SetLibAVLogLevelDebug sets libav errors to debug log level
 func SetLibAVLogLevelDebug() {
 	C.av_log_set_level(C.AV_LOG_DEBUG)
 }

--- a/go.mod
+++ b/go.mod
@@ -342,4 +342,5 @@ require (
 )
 
 // replace github.com/viam-modules/video-store => ../video-store
-replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250220191856-31a337672473
+
+replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250221220458-2671ed89339e

--- a/go.mod
+++ b/go.mod
@@ -343,4 +343,4 @@ require (
 
 // replace github.com/viam-modules/video-store => ../video-store
 
-replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250224154125-83a7372aa76a
+replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250224161434-47663392dfd8

--- a/go.mod
+++ b/go.mod
@@ -343,4 +343,4 @@ require (
 
 // replace github.com/viam-modules/video-store => ../video-store
 
-replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250221220458-2671ed89339e
+replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250224154125-83a7372aa76a

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pion/rtp v1.8.11
 	github.com/rhysd/actionlint v1.6.27
 	github.com/stretchr/testify v1.10.0
-	github.com/viam-modules/video-store v0.0.0-00010101000000-000000000000
+	github.com/viam-modules/video-store v0.0.5-rc1
 	go.uber.org/zap v1.27.0
 	go.viam.com/rdk v0.57.1-0.20250108163155-2071720cd8d3
 	go.viam.com/test v1.2.4

--- a/go.mod
+++ b/go.mod
@@ -341,4 +341,4 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/viam-modules/video-store => ./video-store
+replace github.com/viam-modules/video-store => ../video-store

--- a/go.mod
+++ b/go.mod
@@ -340,7 +340,3 @@ require (
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-// replace github.com/viam-modules/video-store => ../video-store
-
-replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250224163234-757bb51feb9e

--- a/go.mod
+++ b/go.mod
@@ -343,4 +343,4 @@ require (
 
 // replace github.com/viam-modules/video-store => ../video-store
 
-replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250224161434-47663392dfd8
+replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250224163234-757bb51feb9e

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pion/rtp v1.8.11
 	github.com/rhysd/actionlint v1.6.27
 	github.com/stretchr/testify v1.10.0
+	github.com/viam-modules/video-store v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.27.0
 	go.viam.com/rdk v0.57.1-0.20250108163155-2071720cd8d3
 	go.viam.com/test v1.2.4
@@ -97,7 +98,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/firefart/nonamedreturns v1.0.5 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fullstorydev/grpcurl v1.8.6 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/gen2brain/malgo v0.11.21 // indirect
@@ -339,3 +340,5 @@ require (
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace github.com/viam-modules/video-store => ./video-store

--- a/go.mod
+++ b/go.mod
@@ -342,4 +342,4 @@ require (
 )
 
 // replace github.com/viam-modules/video-store => ../video-store
-replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250220155816-d85ccc4c91e8
+replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250220191856-31a337672473

--- a/go.mod
+++ b/go.mod
@@ -341,4 +341,5 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/viam-modules/video-store => ../video-store
+// replace github.com/viam-modules/video-store => ../video-store
+replace github.com/viam-modules/video-store => github.com/nicksanford/video-store v0.0.0-20250220155816-d85ccc4c91e8

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250224154125-83a7372aa76a h1:3KOPMTevm2Xgwewl0SzUAVyq6kwgEWt4G/CcgB/xuXA=
-github.com/nicksanford/video-store v0.0.0-20250224154125-83a7372aa76a/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
+github.com/nicksanford/video-store v0.0.0-20250224161434-47663392dfd8 h1:caO+/q0KkFm7r/w3/CqkIwjsAPMOssrilygsfjO2W9c=
+github.com/nicksanford/video-store v0.0.0-20250224161434-47663392dfd8/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250224161434-47663392dfd8 h1:caO+/q0KkFm7r/w3/CqkIwjsAPMOssrilygsfjO2W9c=
-github.com/nicksanford/video-store v0.0.0-20250224161434-47663392dfd8/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
+github.com/nicksanford/video-store v0.0.0-20250224163234-757bb51feb9e h1:7CxO8H1ErRsLCbhZtlJsCseVU/yw3zIWK2X+3LP9g8g=
+github.com/nicksanford/video-store v0.0.0-20250224163234-757bb51feb9e/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250213230151-85d167e53429 h1:jNXo5Hjem2aXSQ0pWMzzt7B6U1EE3FoxOa+YMloRyzo=
-github.com/nicksanford/video-store v0.0.0-20250213230151-85d167e53429/go.mod h1:+ywAnBUIOeLNBHjqUMefRP2MqMNs7LfWtyh+ifdAQCY=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250220155816-d85ccc4c91e8 h1:Pkfr+IW7SNR7TUlH8nCHZRHJpta6Lxd+u7X0CZVNl2k=
-github.com/nicksanford/video-store v0.0.0-20250220155816-d85ccc4c91e8/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
+github.com/nicksanford/video-store v0.0.0-20250220191856-31a337672473 h1:UeLI1EMnfg/SyUC1phuLVsib6TQjT8L8jiFVag+D66U=
+github.com/nicksanford/video-store v0.0.0-20250220191856-31a337672473/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250221220458-2671ed89339e h1:bE31ckphbPBkOFSIxI/w+aTSpHt4MSHSUhoaHclXMh8=
-github.com/nicksanford/video-store v0.0.0-20250221220458-2671ed89339e/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
+github.com/nicksanford/video-store v0.0.0-20250224154125-83a7372aa76a h1:3KOPMTevm2Xgwewl0SzUAVyq6kwgEWt4G/CcgB/xuXA=
+github.com/nicksanford/video-store v0.0.0-20250224154125-83a7372aa76a/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/nicksanford/video-store v0.0.0-20250220155816-d85ccc4c91e8 h1:Pkfr+IW7SNR7TUlH8nCHZRHJpta6Lxd+u7X0CZVNl2k=
+github.com/nicksanford/video-store v0.0.0-20250220155816-d85ccc4c91e8/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fullstorydev/grpcurl v1.8.6 h1:WylAwnPauJIofYSHqqMTC1eEfUIzqzevXyogBxnQquo=
 github.com/fullstorydev/grpcurl v1.8.6/go.mod h1:WhP7fRQdhxz2TkL97u+TCb505sxfH78W1usyoB3tepw=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
@@ -869,6 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/nicksanford/video-store v0.0.0-20250213230151-85d167e53429 h1:jNXo5Hjem2aXSQ0pWMzzt7B6U1EE3FoxOa+YMloRyzo=
+github.com/nicksanford/video-store v0.0.0-20250213230151-85d167e53429/go.mod h1:+ywAnBUIOeLNBHjqUMefRP2MqMNs7LfWtyh+ifdAQCY=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=
@@ -1565,7 +1567,6 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/nicksanford/video-store v0.0.0-20250221220458-2671ed89339e h1:bE31ckphbPBkOFSIxI/w+aTSpHt4MSHSUhoaHclXMh8=
+github.com/nicksanford/video-store v0.0.0-20250221220458-2671ed89339e/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250220191856-31a337672473 h1:UeLI1EMnfg/SyUC1phuLVsib6TQjT8L8jiFVag+D66U=
-github.com/nicksanford/video-store v0.0.0-20250220191856-31a337672473/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksanford/video-store v0.0.0-20250224163234-757bb51feb9e h1:7CxO8H1ErRsLCbhZtlJsCseVU/yw3zIWK2X+3LP9g8g=
-github.com/nicksanford/video-store v0.0.0-20250224163234-757bb51feb9e/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=
@@ -1227,6 +1225,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/viam-modules/video-store v0.0.5-rc1 h1:DLQNtlTaUsxo+zn7mauIuGrRuUU1WuZZ8dCZ/tX2Xpg=
+github.com/viam-modules/video-store v0.0.5-rc1/go.mod h1:xpsP/tiwg0aeunNmpAt/M1X4Vk+MpaszZcuuAhKN7JE=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=

--- a/mime.go
+++ b/mime.go
@@ -1,7 +1,6 @@
 package viamrtsp
 
 /*
-#cgo pkg-config: libavutil libavcodec libswscale
 #include <libavcodec/avcodec.h>
 #include <libavutil/error.h>
 #include <libavutil/opt.h>

--- a/mime_cgo.go
+++ b/mime_cgo.go
@@ -1,7 +1,6 @@
 package viamrtsp
 
 /*
-#cgo pkg-config: libavutil libavcodec
 #include <libavcodec/avcodec.h>
 #include <libavutil/frame.h>
 #include <libavutil/imgutils.h>

--- a/rtsp.go
+++ b/rtsp.go
@@ -55,7 +55,7 @@ const (
 	defaultMPEG4ProfileLevelID = 1
 	defaultSegmentSeconds      = 30 // seconds
 	defaultUploadPath          = ".viam/capture/video-upload"
-	defaultStoragePath         = ".viam/video-storage"
+	defaultStoragePath         = ".viam/video-storage-viamrtsp"
 	maxGRPCSize                = 1024 * 1024 * 32 // bytes
 	videoStoreInitCloseTimeout = time.Second * 10
 )

--- a/rtsp.go
+++ b/rtsp.go
@@ -27,9 +27,8 @@ import (
 	"github.com/erh/viamupnp"
 	"github.com/pion/rtp"
 	"github.com/viam-modules/viamrtsp/formatprocessor"
-	"go.uber.org/zap/zapcore"
-
 	"github.com/viam-modules/video-store/videostore"
+	"go.uber.org/zap/zapcore"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
@@ -54,11 +53,11 @@ const (
 	// defaultMPEG4ProfileLevelID is the default profile-level-id value for MPEG4 video
 	// as specified in RFC 6416 Section 7.1 https://datatracker.ietf.org/doc/html/rfc6416#section-7.1
 	defaultMPEG4ProfileLevelID = 1
-	initialFramePoolSize       = 5
 	defaultSegmentSeconds      = 30 // seconds
 	defaultUploadPath          = ".viam/capture/video-upload"
 	defaultStoragePath         = ".viam/video-storage"
 	maxGRPCSize                = 1024 * 1024 * 32 // bytes
+	videoStoreInitCloseTimeout = time.Second * 10
 )
 
 var (
@@ -289,7 +288,7 @@ func (rc *rtspCamera) closeConnection() {
 	}
 
 	if rc.vs != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		ctx, cancel := context.WithTimeout(context.Background(), videoStoreInitCloseTimeout)
 		defer cancel()
 		if err := rc.vs.Close(ctx); err != nil {
 			rc.logger.Error(err.Error())
@@ -464,9 +463,9 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 	// setup RTP/H264 -> H264 decoder
 	var f *format.H264
 
-	//TODO: Figure out if this is the right place to put this
+	// TODO: Figure out if this is the right place to put this
 	if rc.vsConfig != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		ctx, cancel := context.WithTimeout(context.Background(), videoStoreInitCloseTimeout)
 		defer cancel()
 		vs, err := videostore.NewH264RTPVideoStore(ctx, *rc.vsConfig, rc.logger)
 		if err != nil {

--- a/rtsp.go
+++ b/rtsp.go
@@ -88,10 +88,9 @@ func init() {
 }
 
 type videoStoreStorageConfig struct {
-	SegmentSeconds int    `json:"segment_seconds,omitempty"`
-	SizeGB         int    `json:"size_gb"`
-	UploadPath     string `json:"upload_path,omitempty"`
-	StoragePath    string `json:"storage_path,omitempty"`
+	SizeGB      int    `json:"size_gb"`
+	UploadPath  string `json:"upload_path,omitempty"`
+	StoragePath string `json:"storage_path,omitempty"`
 }
 
 type videoStoreConfig struct {

--- a/rtsp.go
+++ b/rtsp.go
@@ -227,20 +227,13 @@ type rtspCamera struct {
 
 // Close closes the camera. It always returns nil, but because of Close() interface, it needs to return an error.
 func (rc *rtspCamera) Close(_ context.Context) error {
-	rc.logger.Info("close called")
 	rc.cancelFunc()
-	rc.logger.Info("before closeMu.Lock")
 	rc.closeMu.Lock()
 	defer rc.closeMu.Unlock()
-	rc.logger.Info("before unsubscribeAll")
 	rc.unsubscribeAll()
-	rc.logger.Info("before activeBackgroundWorkers.Wait")
 	rc.activeBackgroundWorkers.Wait()
-	rc.logger.Info("before closeConnection")
 	rc.closeConnection()
-	rc.logger.Info("before close")
 	rc.avFramePool.close()
-	rc.logger.Info("before close")
 	rc.mimeHandler.close()
 	return nil
 }
@@ -471,7 +464,6 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 	// setup RTP/H264 -> H264 decoder
 	var f *format.H264
 
-	// TODO: Figure out if this is the right place to put this
 	if rc.vsConfig != nil {
 		rc.logger.Info("creating video-store from config")
 		ctx, cancel := context.WithTimeout(context.Background(), videoStoreInitCloseTimeout)
@@ -480,7 +472,6 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		if err != nil {
 			return err
 		}
-		// TODO set this to nil on reconnect
 		rc.vs = vs
 	}
 	media := session.FindFormat(&f)
@@ -507,7 +498,6 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 	if rc.vs != nil {
 		rc.logger.Info("video-store is not nil, attempting to call InitH264")
 		if len(f.SPS) != 0 && len(f.PPS) != 0 {
-			// TODO: have approach to tease out
 			if err := rc.vs.InitH264(f.SPS, f.PPS); err != nil {
 				rc.logger.Errorf("videostore.InitH264 error: %s", err.Error())
 				return err
@@ -1084,7 +1074,6 @@ func (rc *rtspCamera) Unsubscribe(_ context.Context, id rtppassthrough.Subscript
 
 // NewRTSPCamera creates a new rtsp camera from the config, that has to have a viamrtsp.Config.
 func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger) (camera.Camera, error) {
-	// SetLibAVLogLevelDebug()
 	if logger.Level() != zapcore.DebugLevel {
 		logger.Info("suppressing non fatal libav errors / warnings due to false positives. to unsuppress, set module log_level to 'debug'")
 		SetLibAVLogLevelFatal()
@@ -1508,7 +1497,6 @@ func (rc *rtspCamera) DoCommand(ctx context.Context, command map[string]interfac
 		return ret, nil
 	case "fetch":
 		rc.logger.Debug("fetch command received")
-		// vs.logger.Debug("video bytes: ", len(videoBytes))
 		req, err := toFetchCommand(command)
 		if err != nil {
 			return nil, err

--- a/rtsp.go
+++ b/rtsp.go
@@ -227,13 +227,20 @@ type rtspCamera struct {
 
 // Close closes the camera. It always returns nil, but because of Close() interface, it needs to return an error.
 func (rc *rtspCamera) Close(_ context.Context) error {
+	rc.logger.Info("close called")
 	rc.cancelFunc()
+	rc.logger.Info("before closeMu.Lock")
 	rc.closeMu.Lock()
 	defer rc.closeMu.Unlock()
+	rc.logger.Info("before unsubscribeAll")
 	rc.unsubscribeAll()
+	rc.logger.Info("before activeBackgroundWorkers.Wait")
 	rc.activeBackgroundWorkers.Wait()
+	rc.logger.Info("before closeConnection")
 	rc.closeConnection()
+	rc.logger.Info("before close")
 	rc.avFramePool.close()
+	rc.logger.Info("before close")
 	rc.mimeHandler.close()
 	return nil
 }

--- a/rtsp.go
+++ b/rtsp.go
@@ -1162,9 +1162,6 @@ func getHomeDir() (string, error) {
 
 func applyStorageDefaults(c videoStoreStorageConfig, name string) (videostore.StorageConfig, error) {
 	var zero videostore.StorageConfig
-	if c.SegmentSeconds == 0 {
-		c.SegmentSeconds = defaultSegmentSeconds
-	}
 	if c.UploadPath == "" {
 		home, err := getHomeDir()
 		if err != nil {
@@ -1180,7 +1177,7 @@ func applyStorageDefaults(c videoStoreStorageConfig, name string) (videostore.St
 		c.StoragePath = filepath.Join(home, defaultStoragePath, name)
 	}
 	return videostore.StorageConfig{
-		SegmentSeconds:       c.SegmentSeconds,
+		SegmentSeconds:       defaultSegmentSeconds,
 		SizeGB:               c.SizeGB,
 		OutputFileNamePrefix: name,
 		UploadPath:           c.UploadPath,

--- a/rtsp.go
+++ b/rtsp.go
@@ -3,9 +3,12 @@ package viamrtsp
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +28,8 @@ import (
 	"github.com/pion/rtp"
 	"github.com/viam-modules/viamrtsp/formatprocessor"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/viam-modules/video-store/videostore"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
@@ -49,6 +54,11 @@ const (
 	// defaultMPEG4ProfileLevelID is the default profile-level-id value for MPEG4 video
 	// as specified in RFC 6416 Section 7.1 https://datatracker.ietf.org/doc/html/rfc6416#section-7.1
 	defaultMPEG4ProfileLevelID = 1
+	initialFramePoolSize       = 5
+	defaultSegmentSeconds      = 30 // seconds
+	defaultUploadPath          = ".viam/capture/video-upload"
+	defaultStoragePath         = ".viam/video-storage"
+	maxGRPCSize                = 1024 * 1024 * 32 // bytes
 )
 
 var (
@@ -78,6 +88,17 @@ func init() {
 	}
 }
 
+type videoStoreStorageConfig struct {
+	SegmentSeconds int    `json:"segment_seconds,omitempty"`
+	SizeGB         int    `json:"size_gb"`
+	UploadPath     string `json:"upload_path,omitempty"`
+	StoragePath    string `json:"storage_path,omitempty"`
+}
+
+type videoStoreConfig struct {
+	Storage videoStoreStorageConfig `json:"storage"`
+}
+
 // Config are the config attributes for an RTSP camera model.
 type Config struct {
 	Address          string               `json:"rtsp_address"`
@@ -85,6 +106,7 @@ type Config struct {
 	LazyDecode       bool                 `json:"lazy_decode,omitempty"`
 	IframeOnlyDecode bool                 `json:"i_frame_only_decode,omitempty"`
 	Query            viamupnp.DeviceQuery `json:"query,omitempty"`
+	VideoStore       *videoStoreConfig    `json:"video_store,omitempty"`
 }
 
 // CodecFormat contains a pointer to a format and the corresponding FFmpeg codec.
@@ -98,6 +120,21 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	_, err := base.ParseURL(conf.Address)
 	if err != nil {
 		return nil, fmt.Errorf("invalid address '%s' for component at path '%s': %w", conf.Address, path, err)
+	}
+
+	if conf.VideoStore != nil {
+		logging.Global().Infof("VideoStore: %#v", *conf.VideoStore)
+		sc, err := applyStorageDefaults(conf.VideoStore.Storage, "anyname")
+		if err != nil {
+			return nil, err
+		}
+		vsc := videostore.Config{
+			Type:    videostore.SourceTypeH264RTPPacket,
+			Storage: sc,
+		}
+		if err := vsc.Validate(); err != nil {
+			return nil, err
+		}
 	}
 
 	return nil, nil
@@ -149,8 +186,9 @@ type rtspCamera struct {
 	lazyDecode       bool
 	iframeOnlyDecode bool
 
-	closeMu sync.RWMutex
-
+	closeMu    sync.RWMutex
+	vsConfig   *videostore.Config
+	vs         videostore.H264RTPVideoStore
 	auMu       sync.Mutex
 	au         [][]byte
 	client     *gortsplib.Client
@@ -248,6 +286,14 @@ func (rc *rtspCamera) closeConnection() {
 	if rc.rawDecoder != nil {
 		rc.rawDecoder.close()
 		rc.rawDecoder = nil
+	}
+
+	if rc.vs != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		if err := rc.vs.Close(ctx); err != nil {
+			rc.logger.Error(err.Error())
+		}
 	}
 }
 
@@ -418,6 +464,17 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 	// setup RTP/H264 -> H264 decoder
 	var f *format.H264
 
+	//TODO: Figure out if this is the right place to put this
+	if rc.vsConfig != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		vs, err := videostore.NewH264RTPVideoStore(ctx, *rc.vsConfig, rc.logger)
+		if err != nil {
+			return err
+		}
+		// TODO set this to nil on reconnect
+		rc.vs = vs
+	}
 	media := session.FindFormat(&f)
 	if media == nil {
 		rc.logger.Warn("tracks available")
@@ -439,6 +496,13 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		return fmt.Errorf("creating H264 raw decoder: %w", err)
 	}
 
+	if rc.vs != nil && len(f.SPS) != 0 && len(f.PPS) != 0 {
+		// TODO: have approach to tease out
+		if err := rc.vs.InitH264(f.SPS, f.PPS); err != nil {
+			return err
+		}
+	}
+
 	// if SPS and PPS are present into the SDP, send them to the decoder
 	initialSPSAndPPS := [][]byte{}
 	if f.SPS != nil {
@@ -453,15 +517,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 	}
 
 	var receivedFirstIDR bool
-	storeImage := func(pkt *rtp.Packet) {
-		au, err := rtpDec.Decode(pkt)
-		if err != nil {
-			if !errors.Is(err, rtph264.ErrNonStartingPacketAndNoPrevious) && !errors.Is(err, rtph264.ErrMorePacketsNeeded) {
-				rc.logger.Debugf("error decoding(1) h264 rstp stream %w", err)
-			}
-			return
-		}
-
+	storeImage := func(au [][]byte) {
 		if !receivedFirstIDR && h264.IDRPresent(au) {
 			rc.logger.Debug("adding initial SPS & PPS")
 			receivedFirstIDR = true
@@ -485,8 +541,48 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		}
 	}
 
+	var receivedFirstSegmentKeyframe bool
+	segmentPacket := func(pkt *rtp.Packet, au [][]byte) {
+		if rc.vs == nil {
+			return
+		}
+		pts, ok := rc.client.PacketPTS2(media, pkt)
+		if !ok {
+			rc.logger.Debug("no pts found for packet")
+			return
+		}
+		// Video files must start with a keyframe. Wait for the first keyframe before starting to
+		// segment the video.
+		if !receivedFirstSegmentKeyframe {
+			if h264.IDRPresent(au) {
+				rc.logger.Debug("segmenter found first segment keyframe")
+				receivedFirstSegmentKeyframe = true
+			} else {
+				rc.logger.Debug("segmenter is waiting for first keyframe")
+				return
+			}
+		}
+		packed, err := h264.AVCCMarshal(au)
+		if err != nil {
+			rc.logger.Errorf("AnnexBMarshal err: %s", err.Error())
+			return
+		}
+		err = rc.vs.WritePacket(packed, pts, h264.IDRPresent(au))
+		if err != nil {
+			rc.logger.Errorf("error writing packet to segmenter: %s", err)
+		}
+	}
+
 	onPacketRTP := func(pkt *rtp.Packet) {
-		storeImage(pkt)
+		au, err := rtpDec.Decode(pkt)
+		if err != nil {
+			if !errors.Is(err, rtph264.ErrNonStartingPacketAndNoPrevious) && !errors.Is(err, rtph264.ErrMorePacketsNeeded) {
+				rc.logger.Debugf("error decoding(1) h264 rstp stream %w", err)
+			}
+			return
+		}
+		storeImage(au)
+		segmentPacket(pkt, au)
 	}
 
 	if rc.rtpPassthrough {
@@ -522,7 +618,15 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 
 		onPacketRTP = func(pkt *rtp.Packet) {
 			publishToWebRTC(pkt)
-			storeImage(pkt)
+			au, err := rtpDec.Decode(pkt)
+			if err != nil {
+				if !errors.Is(err, rtph264.ErrNonStartingPacketAndNoPrevious) && !errors.Is(err, rtph264.ErrMorePacketsNeeded) {
+					rc.logger.Debugf("error decoding(1) h264 rstp stream %w", err)
+				}
+				return
+			}
+			storeImage(au)
+			segmentPacket(pkt, au)
 		}
 	}
 
@@ -540,6 +644,10 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 	if rc.rtpPassthrough {
 		rc.logger.Warn("rtp_passthrough is only supported for H264 codec. rtp_passthrough features disabled due to H265 RTSP track")
+	}
+
+	if rc.vsConfig != nil {
+		rc.logger.Warn("video_store is only supported for H264 codec. video_store features disabled due to H265 RTSP track")
 	}
 
 	var f *format.H265
@@ -673,6 +781,10 @@ func (rc *rtspCamera) initMJPEG(session *description.Session) error {
 			"lazy_decode features disabled due to MJPEG RTSP track")
 	}
 
+	if rc.vsConfig != nil {
+		rc.logger.Warn("video_store is only supported for H264 codec. video_store features disabled due to MJPEG RTSP track")
+	}
+
 	var f *format.MJPEG
 	media := session.FindFormat(&f)
 	if media == nil {
@@ -764,6 +876,10 @@ func (rc *rtspCamera) initMPEG4(session *description.Session) error {
 	if rc.iframeOnlyDecode {
 		rc.logger.Warn("i_frame_only_decode is currently only supported for H264 and H265 codecs. " +
 			"lazy_decode features disabled due to MPEG4 RTSP track")
+	}
+
+	if rc.vsConfig != nil {
+		rc.logger.Warn("video_store is only supported for H264 codec. video_store features disabled due to MPEG4 RTSP track")
 	}
 
 	var f *format.MPEG4Video
@@ -953,6 +1069,7 @@ func (rc *rtspCamera) Unsubscribe(_ context.Context, id rtppassthrough.Subscript
 
 // NewRTSPCamera creates a new rtsp camera from the config, that has to have a viamrtsp.Config.
 func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger) (camera.Camera, error) {
+	// SetLibAVLogLevelDebug()
 	if logger.Level() != zapcore.DebugLevel {
 		logger.Info("suppressing non fatal libav errors / warnings due to false positives. to unsuppress, set module log_level to 'debug'")
 		SetLibAVLogLevelFatal()
@@ -978,12 +1095,30 @@ func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 		rtpPassthrough = *newConf.RTPPassthrough
 	}
 
+	var vsc *videostore.Config
+	if newConf.VideoStore != nil {
+		sc, err := applyStorageDefaults(newConf.VideoStore.Storage, conf.ResourceName().Name)
+		if err != nil {
+			return nil, err
+		}
+		tmpVsc := videostore.Config{
+			Type:    videostore.SourceTypeH264RTPPacket,
+			Storage: sc,
+		}
+		if err := tmpVsc.Validate(); err != nil {
+			return nil, err
+		}
+
+		vsc = &tmpVsc
+	}
+
 	rtpPassthroughCtx, rtpPassthroughCancelCauseFn := context.WithCancelCause(context.Background())
 	rc := &rtspCamera{
 		model:                       conf.Model,
 		lazyDecode:                  newConf.LazyDecode,
 		iframeOnlyDecode:            newConf.IframeOnlyDecode,
 		u:                           u,
+		vsConfig:                    vsc,
 		name:                        conf.ResourceName(),
 		rtpPassthrough:              rtpPassthrough,
 		bufAndCBByID:                make(map[rtppassthrough.SubscriptionID]bufAndCB),
@@ -1011,6 +1146,43 @@ func NewRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 	rc.clientReconnectBackgroundWorker(codecInfo)
 
 	return rc, nil
+}
+
+// getHomeDir returns the home directory of the user.
+func getHomeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return home, nil
+}
+
+func applyStorageDefaults(c videoStoreStorageConfig, name string) (videostore.StorageConfig, error) {
+	var zero videostore.StorageConfig
+	if c.SegmentSeconds == 0 {
+		c.SegmentSeconds = defaultSegmentSeconds
+	}
+	if c.UploadPath == "" {
+		home, err := getHomeDir()
+		if err != nil {
+			return zero, err
+		}
+		c.UploadPath = filepath.Join(home, defaultUploadPath, name)
+	}
+	if c.StoragePath == "" {
+		home, err := getHomeDir()
+		if err != nil {
+			return zero, err
+		}
+		c.StoragePath = filepath.Join(home, defaultStoragePath, name)
+	}
+	return videostore.StorageConfig{
+		SegmentSeconds:       c.SegmentSeconds,
+		SizeGB:               c.SizeGB,
+		OutputFileNamePrefix: name,
+		UploadPath:           c.UploadPath,
+		StoragePath:          c.StoragePath,
+	}, nil
 }
 
 func (rc *rtspCamera) unsubscribeAll() {
@@ -1285,6 +1457,114 @@ func (rc *rtspCamera) NextPointCloud(_ context.Context) (pointcloud.PointCloud, 
 	return nil, errors.New("not implemented")
 }
 
-func (rc *rtspCamera) DoCommand(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
-	return nil, errors.New("not implemented")
+func (rc *rtspCamera) DoCommand(ctx context.Context, command map[string]interface{}) (map[string]interface{}, error) {
+	if rc.vs == nil {
+		return nil, errors.New("not implemented")
+	}
+	cmd, ok := command["command"].(string)
+	if !ok {
+		return nil, errors.New("invalid command type")
+	}
+
+	switch cmd {
+	// Save command is used to concatenate video clips between the given timestamps.
+	// The concatenated video file is then uploaded to the cloud the upload path.
+	// The response contains the name of the uploaded file.
+	case "save":
+		rc.logger.Debug("save command received")
+		req, err := toSaveCommand(command)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := rc.vs.Save(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		ret := map[string]interface{}{
+			"command":  "save",
+			"filename": res.Filename,
+		}
+
+		if req.Async {
+			ret["status"] = "async"
+		}
+		return ret, nil
+	case "fetch":
+		rc.logger.Debug("fetch command received")
+		// vs.logger.Debug("video bytes: ", len(videoBytes))
+		req, err := toFetchCommand(command)
+		if err != nil {
+			return nil, err
+		}
+		res, err := rc.vs.Fetch(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		if len(res.Video) > maxGRPCSize {
+			return nil, errors.New("video file size exceeds max grpc size")
+		}
+		// TODO(seanp): Do we need to encode the video bytes to base64?
+		videoBytesBase64 := base64.StdEncoding.EncodeToString(res.Video)
+		return map[string]interface{}{
+			"command": "fetch",
+			"video":   videoBytesBase64,
+		}, nil
+	default:
+		return nil, errors.New("invalid command")
+	}
+}
+
+func toSaveCommand(command map[string]interface{}) (*videostore.SaveRequest, error) {
+	fromStr, ok := command["from"].(string)
+	if !ok {
+		return nil, errors.New("from timestamp not found")
+	}
+	from, err := videostore.ParseDateTimeString(fromStr)
+	if err != nil {
+		return nil, err
+	}
+	toStr, ok := command["to"].(string)
+	if !ok {
+		return nil, errors.New("to timestamp not found")
+	}
+	to, err := videostore.ParseDateTimeString(toStr)
+	if err != nil {
+		return nil, err
+	}
+	metadata, ok := command["metadata"].(string)
+	if !ok {
+		metadata = ""
+	}
+	async, ok := command["async"].(bool)
+	if !ok {
+		async = false
+	}
+	return &videostore.SaveRequest{
+		From:     from,
+		To:       to,
+		Metadata: metadata,
+		Async:    async,
+	}, nil
+}
+
+func toFetchCommand(command map[string]interface{}) (*videostore.FetchRequest, error) {
+	fromStr, ok := command["from"].(string)
+	if !ok {
+		return nil, errors.New("from timestamp not found")
+	}
+	from, err := videostore.ParseDateTimeString(fromStr)
+	if err != nil {
+		return nil, err
+	}
+	toStr, ok := command["to"].(string)
+	if !ok {
+		return nil, errors.New("to timestamp not found")
+	}
+	to, err := videostore.ParseDateTimeString(toStr)
+	if err != nil {
+		return nil, err
+	}
+	return &videostore.FetchRequest{From: from, To: to}, nil
 }


### PR DESCRIPTION
1. Disables building android releases - this is b/c the android build requires not using cgo. Embeding viarmtsp into video-store requires cgo. Android builds of viamrtsp are not going to be able to have the video-store features. I'm haven't done the work to allow for both cgo (with video-store) and non cgo (without video-store) builds of viamrtsp. That will need to be done as a follow up.
2.  Allows the following config to enable video-store features:
```
{
"video_store": {
"size_gb" int,
"upload_path": int,
"storage_path": int
}
}
```