### PR TITLE
[RSDK-10071] - Fix avFramePool memory leak

### DIFF
--- a/rtsp.go
+++ b/rtsp.go
@@ -232,7 +232,7 @@ func (rc *rtspCamera) Close(_ context.Context) error {
 	rc.unsubscribeAll()
 	rc.activeBackgroundWorkers.Wait()
 	rc.closeConnection()
-	// Clean up latest frame if it exists. This is necessary to ensure that the frame is properly
+	// Clean up latestFrame cache if it exists. This is necessary to ensure that the frame is properly
 	// freed when the avFramePool is closed.
 	rc.latestFrameMu.Lock()
 	if rc.latestFrame != nil {

--- a/rtsp.go
+++ b/rtsp.go
@@ -232,6 +232,7 @@ func (rc *rtspCamera) Close(_ context.Context) error {
 	rc.unsubscribeAll()
 	rc.activeBackgroundWorkers.Wait()
 	rc.closeConnection()
+	rc.mimeHandler.close()
 	// Clean up latestFrame cache if it exists. This is necessary to ensure that the frame is properly
 	// freed when the avFramePool is closed.
 	rc.latestFrameMu.Lock()
@@ -243,7 +244,6 @@ func (rc *rtspCamera) Close(_ context.Context) error {
 	}
 	rc.latestFrameMu.Unlock()
 	rc.avFramePool.close()
-	rc.mimeHandler.close()
 	return nil
 }
 

--- a/rtsp_test.go
+++ b/rtsp_test.go
@@ -96,7 +96,6 @@ func TestRTSPCamera(t *testing.T) {
 			config.ConvertedAttributes = &Config{Address: "rtsp://" + h.s.RTSPAddress + "/stream1"}
 			rtspCam, err := NewRTSPCamera(timeoutCtx, nil, config, logger)
 			test.That(t, err, test.ShouldBeNil)
-			defer func() { test.That(t, rtspCam.Close(context.Background()), test.ShouldBeNil) }()
 			imageTimeoutCtx, imageTimeoutCancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer imageTimeoutCancel()
 			// Fetch images while allowing the pool to grow and shrink as needed.


### PR DESCRIPTION
## Description

There is an issue where we are never releasing the `latestFrame` cache back to the pool during closeout. When the avFramePool closes out the latest frame never gets freed causing a lingering frame allocation.

## Testing

### Manual Testing
- We can see that when properly releasing the frame we are now freeing more frames during closeout. See the following logs -- first log set is from upstream and the second is the feature branch.
- Manually verified memory usage with `top` does not increase from disabling and re-enabling viamrtsp component.

```
3/3/2025, 4:52:34 PM info rdk:component:camera/rtsp-cam-3     host/pool.go:112 Num pool frames remaining at close: 1   log_ts 2025-03-03T21:52:34.154Z

```

```
3/3/2025, 4:57:51 PM info rdk:component:camera/rtsp-cam-3     host/pool.go:112 Num pool frames remaining at close: 2   log_ts 2025-03-03T21:57:51.675Z

```


### Automated Tests

- Added test case to make sure we put as many frames as received back into the pool.
  - If you comment out the close frame put we see the test fails with a lingering frame.
  
 ```
      --- FAIL: TestRTSPCamera/H264 (5.84s)
        --- FAIL: TestRTSPCamera/H264/AvFramePool (3.80s)
            rtsp_test.go:122: Expected: '16'
                Actual:   '15'
                (Should be equal)
FAIL
FAIL    github.com/viam-modules/viamrtsp        5.943s
FAIL
```