### PR TITLE
RSDK-10260: Use updated zeroconf that responds to plain mDNS questions.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/bluenviron/gortsplib/v4 v4.12.2
 	github.com/bluenviron/mediacommon v1.13.3
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
-	github.com/edaniels/zeroconf v1.0.10
 	github.com/elgs/gostrgen v0.0.0-20161222160715-9d61ae07eeae
 	github.com/erh/viamupnp v0.0.0-20250225174543-39c68c119b3e
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -19,6 +18,7 @@ require (
 	github.com/rhysd/actionlint v1.6.27
 	github.com/stretchr/testify v1.10.0
 	github.com/viam-modules/video-store v0.0.5-rc4
+	github.com/viamrobotics/zeroconf v1.0.12
 	go.uber.org/zap v1.27.0
 	go.viam.com/rdk v0.65.0
 	go.viam.com/test v1.2.4
@@ -90,6 +90,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0 // indirect
 	github.com/edaniels/lidario v0.0.0-20220607182921-5879aa7b96dd // indirect
+	github.com/edaniels/zeroconf v1.0.10 // indirect
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1231,6 +1231,8 @@ github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWj
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=
 github.com/viamrobotics/webrtc/v3 v3.99.10/go.mod h1:ziH7/S52IyYAeDdwUUl5ZTbuyKe47fWorAz+0z5w6NA=
+github.com/viamrobotics/zeroconf v1.0.12 h1:y0AaDnBmELvtKKzJlnRBivZ4KWYXWXyGv73SY16sXUw=
+github.com/viamrobotics/zeroconf v1.0.12/go.mod h1:6qNiiR//WWB7n2c6syvOl0rAGltrcyNW4KonC6OBkPM=
 github.com/wcharczuk/go-chart/v2 v2.1.0/go.mod h1:yx7MvAVNcP/kN9lKXM/NTce4au4DFN99j6i1OwDclNA=
 github.com/wlynxg/anet v0.0.3 h1:PvR53psxFXstc12jelG6f1Lv4MWqE0tI76/hHGjh9rg=
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -146,12 +146,11 @@ func (cam *CameraInfo) tryMDNS(mdnsServer *mdnsServer, logger logging.Logger) {
 		return
 	}
 
-	const swapIPsWithMDNS = false
 	wasIPFound := false
 	// Replace the URLs in-place such that configs generated from these objects will point to the
 	// logical dns hostname rather than a raw IP.
 	for idx := range cam.RTSPURLs {
-		if swapIPsWithMDNS && strings.Contains(cam.RTSPURLs[idx], cam.deviceIP.String()) {
+		if strings.Contains(cam.RTSPURLs[idx], cam.deviceIP.String()) {
 			cam.RTSPURLs[idx] = strings.Replace(cam.RTSPURLs[idx], cam.deviceIP.String(), cam.mdnsName, 1)
 			wasIPFound = true
 		} else {

--- a/viamonvif/mdns_server.go
+++ b/viamonvif/mdns_server.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/edaniels/zeroconf"
+	"github.com/viamrobotics/zeroconf"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/utils"
 )


### PR DESCRIPTION
Demonstrated a `ping` worked for > 2 minutes after running a single discovery request. Added a camera via service discovery config copying.
```
dgottlieb@empanada:~/viam/robotConfigs $ for i in {1..80}; do date; ping -c 1 AMC1083EC3C8118218.local; sleep 60; done
Mon Mar 17 02:12:12 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=3.32 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 3.320/3.320/3.320/0.000 ms
Mon Mar 17 02:13:12 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=2.58 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 2.580/2.580/2.580/0.000 ms
Mon Mar 17 02:14:12 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=41.0 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 41.009/41.009/41.009/0.000 ms
Mon Mar 17 02:15:13 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=3.75 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 3.749/3.749/3.749/0.000 ms
Mon Mar 17 02:16:13 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=1.89 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 1.892/1.892/1.892/0.000 ms
Mon Mar 17 02:17:13 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=5.17 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 5.173/5.173/5.173/0.000 ms
Mon Mar 17 02:18:13 PM EDT 2025
PING AMC1083EC3C8118218.local (10.1.11.241) 56(84) bytes of data.
64 bytes from 10.1.11.241 (10.1.11.241): icmp_seq=1 ttl=64 time=3.65 ms

--- AMC1083EC3C8118218.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 3.646/3.646/3.646/0.000 ms
```