### PR TITLE
[RSDK-10750] Update video-store and RDK dep to serve get-storage-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,88 @@ The response will be preview image in the [DataURL](https://developer.mozilla.or
 }
 ```
 
+### Get Storage State DoCommand
+
+The `get-storage-state` command retrieves the current state of video storage, including available video time ranges and disk usage information.
+
+| Attribute | Type       | Required/Optional | Description          |
+|-----------|------------|-------------------|----------------------|
+| `command` | string     | required          | The command to be executed. Value must be "get-storage-state". |
+
+#### Get Storage State Request
+```json
+{
+  "command": "get-storage-state"
+}
+```
+
+#### Get Storage State Response
+
+The response includes a list of `stored_video` time ranges and `disk_usage` statistics.
+
+```json
+{
+  "command": "get-storage-state",
+  "stored_video": [
+    {
+      "from": "YYYY-MM-DD_HH-MM-SSZ",
+      "to": "YYYY-MM-DD_HH-MM-SSZ"
+    },
+    // ... more ranges
+  ],
+  "disk_usage": {
+    "storage_path": "/path/to/your/storage/directory",
+    "storage_used_gb": 99.98,
+    "storage_limit_gb": 100,
+    "device_storage_remaining_gb": 697.21
+  }
+}
+```
+
+**Response Fields:**
+
+-   `stored_video`: An array of objects, where each object represents a contiguous block of recorded video.
+    -   `from`: The start UTC timestamp of the video block.
+    -   `to`: The end UTC timestamp of the video block.
+-   `disk_usage`:
+    -   `storage_path`: The configured path where video segments are stored.
+    -   `storage_used_gb`: The amount of disk space (in GB) currently used by the video store in its `storage_path`.
+    -   `storage_limit_gb`: The configured maximum disk space (in GB) allocated for the video store.
+    -   `device_storage_remaining_gb`: The remaining free disk space (in GB) on the underlying storage device where `storage_path` is located.
+
+#### Example Get Storage State Response
+
+```json
+{
+  "command": "get-storage-state",
+  "stored_video": [
+    {
+      "to": "2025-05-18_05-59-58Z",
+      "from": "2025-05-17_20-23-08Z"
+    },
+    {
+      "from": "2025-05-18_06-00-35Z",
+      "to": "2025-05-19_13-56-55Z"
+    },
+    {
+      "from": "2025-05-19_13-57-13Z",
+      "to": "2025-05-19_13-58-18Z"
+    }
+    // ... additional video ranges truncated for brevity
+  ],
+  "disk_usage": {
+    "storage_path": "/root/.viam/video-storage/video_camera-XYZ",
+    "storage_used_gb": 99.98937438707799,
+    "storage_limit_gb": 100,
+    "device_storage_remaining_gb": 697.2153244018555
+  }
+}
+```
+
+> [!NOTE]
+> Swapping the `storage_path` config attribute will not delete any data, it will simply cause video store to start persisting video data to the new path and preserve
+the old `storage_path` directory with the old videos and the old database, and save new videos in the new path.
+
 ### Next steps
 
 Use the `DiscoverResources` API by adding a `viam:viamrtsp:onvif` `discovery` model to retrieve a list of cameras discovered by the service and their configuration. You can then retrieve a preview image from a camera using the `Preview` `DoCommand`. 

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,8 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.1.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gobwas/httphead v0.1.0 // indirect
+	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/goccy/go-graphviz v0.1.3 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
@@ -198,6 +200,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mgechev/revive v1.3.9 // indirect
 	github.com/miekg/dns v1.1.53 // indirect
@@ -340,3 +343,5 @@ require (
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace github.com/viam-modules/video-store => ../sean-video-store

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pion/rtp v1.8.11
 	github.com/rhysd/actionlint v1.6.27
 	github.com/stretchr/testify v1.10.0
-	github.com/viam-modules/video-store v0.0.8-rc1
+	github.com/viam-modules/video-store v0.0.8-rc2
 	github.com/viamrobotics/zeroconf v1.0.12
 	go.uber.org/zap v1.27.0
 	go.viam.com/rdk v0.78.2
@@ -343,5 +343,3 @@ require (
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-replace github.com/viam-modules/video-store => ../sean-video-store

--- a/go.sum
+++ b/go.sum
@@ -428,10 +428,12 @@ github.com/go-xmlfmt/xmlfmt v1.1.2 h1:Nea7b4icn8s57fTx1M5AI4qQT5HEM3rVUO8MuE6g80
 github.com/go-xmlfmt/xmlfmt v1.1.2/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
-github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
+github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
+github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
+github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
@@ -821,6 +823,8 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
@@ -1240,8 +1244,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/viam-modules/video-store v0.0.8-rc1 h1:0EOaOBD4c+BV0fX3luBjtZd1EciaEmGJjKpQiQ2Jqiw=
-github.com/viam-modules/video-store v0.0.8-rc1/go.mod h1:Jo/y8+VB+AuocoV4MQiIuiR4r8/ZdiiUhWnjOQ2cCLw=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=

--- a/go.sum
+++ b/go.sum
@@ -1244,6 +1244,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/viam-modules/video-store v0.0.8-rc2 h1:BGaGl21BdXUAGrSJJTcpkSs1qEuar8UIK4X3BJrO+48=
+github.com/viam-modules/video-store v0.0.8-rc2/go.mod h1:qonEngao768mz54CEfBX7YfAPVqKmKWttPhfsruHInk=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -46,6 +46,7 @@ func applyDefaults(cfg *Config, name string) (videostore.Config, error) {
 
 	ec := applyVideoEncoderDefaults(cfg.Video)
 	return videostore.Config{
+		Name:    name,
 		Storage: sc,
 		Encoder: ec,
 		FramePoller: videostore.FramePollerConfig{

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, deps resource.Dependencies, conf resource.Config, 
 			return nil, err
 		}
 		rtpVs, err := videostore.NewRTPVideoStore(ctx, videostore.Config{
-			Name:    conf.ResourceName().Name,
+			Name:    vsConfig.Name,
 			Type:    videostore.SourceTypeRTP,
 			Storage: vsConfig.Storage,
 		}, logger)
@@ -79,7 +79,7 @@ func New(ctx context.Context, deps resource.Dependencies, conf resource.Config, 
 			rtpVs.Close()
 			vsConfig.FramePoller.Camera = c
 			fVs, err := videostore.NewFramePollingVideoStore(ctx, videostore.Config{
-				Name:        conf.ResourceName().Name,
+				Name:        vsConfig.Name,
 				Type:        videostore.SourceTypeFrame,
 				Storage:     vsConfig.Storage,
 				Encoder:     vsConfig.Encoder,
@@ -92,7 +92,7 @@ func New(ctx context.Context, deps resource.Dependencies, conf resource.Config, 
 		}
 	} else {
 		vs, err = videostore.NewReadOnlyVideoStore(ctx, videostore.Config{
-			Name:    conf.ResourceName().Name,
+			Name:    vsConfig.Name,
 			Type:    videostore.SourceTypeReadOnly,
 			Storage: vsConfig.Storage,
 		}, logger)


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-10750

- [x] Get rid of local replacement and upgrade to new version of video-store once its out

# Manual Checks and Tests

## Check CPU utilization (htop) on indexer long run 100gb 10min
To check this, I will screenshot htop before deleting `index.sqlite.db` and then screenshot htop after the deletion when the long index is happening.

<img width="1218" alt="Screenshot 2025-05-20 at 12 45 59 PM" src="https://github.com/user-attachments/assets/20f46c54-1d2c-4b23-b712-92dde5f91669" />
Before^

<img width="1216" alt="Screenshot 2025-05-20 at 12 48 51 PM" src="https://github.com/user-attachments/assets/9e6d0b79-630a-4466-aa4e-f6d5149dbe3f" />
A couple minutes after deleting the .db file^

It looks like nothing crazy is happening. No cores are being maxed out at 100% and the workload looks marginally higher.

## Test rogue user delete of `index.sqlite.db`
This was tested implicitly in the above test by triggering the long index with a during-runtime delete of the .db file.

## Save command while long index is happening
```
{
        "command": "save",
        "from": "2025-05-20_12-53-02",
        "to": "2025-05-20_12-53-12",
        "metadata": "metadata",
        "async": false
}
```

https://github.com/user-attachments/assets/977d43a0-f492-4c00-b80a-398fbee3eae1

Nice!

## Swap capture directory
Swapped dir from default .viam/video-storage to a custom dir. Verified the swap with a subsequent get-storage-state command.

```
{
  "stored_video": [
    {
      "from": "2025-05-20_17-33-00Z",
      "to": "2025-05-20_17-34-03Z"
    }
  ],
  "disk_usage": {
    "device_storage_remaining_gb": 684.6471176147461,
    "storage_path": "/sean-yus-dir/custom-capture-EL5c",
    "storage_used_gb": 0.04542581923305988,
    "storage_limit_gb": 100
  }
}
```

Used `save` command after the swap and verified the video is good. 

Swapped it back to the default and verified the get-storage-state command and we can save old dir videos again.

## Delete videos manually during runtime
get-storage-state before deletion:

```
{
  "disk_usage": {
    "storage_limit_gb": 100,
    "device_storage_remaining_gb": 684.2062759399414,
    "storage_path": "/sean-yus-dir/custom-capture-EL5c",
    "storage_used_gb": 0.42463886365294456
  },
  "stored_video": [
    {
      "to": "2025-05-20_17-39-08Z",
      "from": "2025-05-20_17-33-00Z"
    },
    {
      "from": "2025-05-20_17-42-04Z",
      "to": "2025-05-20_17-45-36Z"
    }
  ]
}
```

Immediately after:

```
{
  "stored_video": [],
  "disk_usage": {
    "device_storage_remaining_gb": 684.6167449951172,
    "storage_path": "/sean-yus-dir/custom-capture-EL5c",
    "storage_used_gb": 0,
    "storage_limit_gb": 100
  }
}
```

Recovered:

```
{
  "disk_usage": {
    "storage_limit_gb": 100,
    "device_storage_remaining_gb": 684.6115036010742,
    "storage_path": "/sean-yus-dir/custom-capture-EL5c",
    "storage_used_gb": 0.021979435347020626
  },
  "stored_video": [
    {
      "from": "2025-05-20_17-46-37Z",
      "to": "2025-05-20_17-47-06Z"
    }
  ]
}
```

Saving new videos.