### PR TITLE
RSDK-10807 - Handle concurrent RTSP preview fallback attempts

### DIFF
--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -3,10 +3,8 @@ package viamonvif
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -337,10 +335,7 @@ func fetchImageFromRTSPURL(ctx context.Context, logger logging.Logger, rtspURL s
 	rtspConfig := viamrtsp.Config{
 		Address: rtspURL,
 	}
-	uniqueName, err := generateUniqueName("tmp-camera")
-	if err != nil {
-		return "", fmt.Errorf("failed to generate unique camera name: %w", err)
-	}
+	uniqueName := generateUniqueName("tmp-camera")
 	resourceConfig := resource.Config{
 		Name:                uniqueName,
 		API:                 camera.API,
@@ -385,15 +380,10 @@ func fetchImageFromRTSPURL(ctx context.Context, logger logging.Logger, rtspURL s
 }
 
 // generateUniqueName creates a unique name by adding timestamp and random bytes
-func generateUniqueName(prefix string) (string, error) {
-	randomBytes := make([]byte, rtspNameSaltLength)
-	if _, err := rand.Read(randomBytes); err != nil {
-		return "", err
-	}
+func generateUniqueName(prefix string) string {
 	timestamp := time.Now().UnixNano()
-	randomHex := hex.EncodeToString(randomBytes)
-	uniqueName := fmt.Sprintf("%s-%d-%s", prefix, timestamp, randomHex)
-	return uniqueName, nil
+	uniqueName := fmt.Sprintf("%s-%d", prefix, timestamp)
+	return uniqueName
 }
 
 func createCamerasFromURLs(l CameraInfo, discoveryDependencyName string, logger logging.Logger) ([]resource.Config, error) {

--- a/viamonvif/service_test.go
+++ b/viamonvif/service_test.go
@@ -407,11 +407,9 @@ func TestDoCommandPreview(t *testing.T) {
 func TestGenerateUniqueName(t *testing.T) {
 	t.Run("Test unique name generation", func(t *testing.T) {
 		prefix := "test-prefix"
-		name1, err := generateUniqueName(prefix)
-		test.That(t, err, test.ShouldBeNil)
+		name1 := generateUniqueName(prefix)
 		test.That(t, strings.HasPrefix(name1, prefix), test.ShouldBeTrue)
-		name2, err := generateUniqueName(prefix)
-		test.That(t, err, test.ShouldBeNil)
+		name2 := generateUniqueName(prefix)
 		test.That(t, strings.HasPrefix(name2, prefix), test.ShouldBeTrue)
 		// Ensure names are unique
 		test.That(t, name1, test.ShouldNotEqual, name2)


### PR DESCRIPTION
## Description

Currently, we hardcode `tmp-camera` as the RTSP preview look up resource name. This causes issue with concurrent spin ups. This PR simply ensures uniqueness for each resource name so we can spin up arbitrary number of concurrent resources.

`camera_name`-`timestamp` -> `tmp-camera-1684263518248967000`

## Tests

Added concurrency test case to the service to make sure the issue has been fixed.