### PR TITLE
[CONSULT-1116] - Background discovery cache

### DIFF
--- a/.github/workflows/quality-test.yml
+++ b/.github/workflows/quality-test.yml
@@ -29,13 +29,6 @@ jobs:
         sudo apt-get update
         sudo add-apt-repository universe && sudo apt-get install -y libfuse2
 
-    - name: Check gofmt
-      run: |
-        if [ -n "$(gofmt -d .)" ]; then
-          echo "gofmt is unhappy with your code quality!! Please run 'make lint' and commit the changes."
-          exit 1
-        fi
-    
     - name: Run linter and static checks
       run: make lint
 

--- a/.github/workflows/quality-test.yml
+++ b/.github/workflows/quality-test.yml
@@ -29,6 +29,13 @@ jobs:
         sudo apt-get update
         sudo add-apt-repository universe && sudo apt-get install -y libfuse2
 
+    - name: Check gofmt
+      run: |
+        if [ -n "$(gofmt -d .)" ]; then
+          echo "gofmt is unhappy with your code quality!! Please run 'make lint' and commit the changes."
+          exit 1
+        fi
+
     - name: Run linter and static checks
       run: make lint
 

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -139,14 +139,12 @@ func (dis *rtspDiscovery) DiscoverResources(ctx context.Context, extra map[strin
 
 	// If we have previously discovered cameras, we will return the cached resources.
 	dis.discoveredResourcesMu.Lock()
-	hasDiscoveredResources := len(dis.discoveredResources) > 0
-	if hasDiscoveredResources {
-		result := dis.discoveredResources
-		dis.discoveredResourcesMu.Unlock()
+	cachedDiscovered := dis.discoveredResources
+        dis.discoveredResourcesMu.Unlock()
+	if len(cachedDiscovered) > 0 {
 		dis.logger.Debug("returning cached discovered resources")
-		return result, nil
+		return cachedDiscovered, nil
 	}
-	dis.discoveredResourcesMu.Unlock()
 
 	// If discovery has not been run before, or no cameras were discovered,
 	// we will attempt the discovery lookup again.

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -127,7 +127,7 @@ func (dis *rtspDiscovery) DiscoverResources(ctx context.Context, extra map[strin
 	// with provided credentials. We ignore any previously discovered resources
 	// and re-run discovery with extra parameters.
 	if len(extra) > 0 {
-		dis.logger.Debugf("Running discovery lookup with extra parameters: %v", extra)
+		dis.logger.Debugf("running discovery lookup with extra parameters: %v", extra)
 		discovered, err := dis.runDiscoveryLookup(ctx, extra)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run discovery lookup: %w", err)
@@ -138,18 +138,18 @@ func (dis *rtspDiscovery) DiscoverResources(ctx context.Context, extra map[strin
 		// lookup again to ensure we have the latest discovered resources.
 		dis.discoveredResourcesMu.Lock()
 		defer dis.discoveredResourcesMu.Unlock()
-		dis.logger.Debug("No extra parameters provided, running discovery lookup")
+		dis.logger.Debug("no extra parameters provided, running discovery lookup with config credentials")
 		discovered, err := dis.runDiscoveryLookup(ctx, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run discovery lookup: %w", err)
 		}
 		dis.discoveredResources = discovered
-		dis.logger.Debug("Discovery lookup completed, resources discovered")
+		dis.logger.Debug("discovered resources available, returning cached results")
 		return dis.discoveredResources, nil
 	}
 
 	// If we have previously discovered cameras, we will return the cached resources.
-	dis.logger.Debug("Returning cached discovered resources")
+	dis.logger.Debug("returning cached discovered resources")
 	return dis.discoveredResources, nil
 }
 

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -285,14 +285,14 @@ func (dis *rtspDiscovery) discoveryBackgroundWorker(ctx context.Context) {
 		case <-ticker.C:
 			dis.discoveredResourcesMu.Lock()
 			if cams, err := dis.runDiscoveryLookup(ctx, nil); err != nil {
-				dis.logger.Errorf("Discovery failed: %v", err)
+				dis.logger.Errorf("discovery failed: %v", err)
 				dis.discoveredResources = cams
 			} else {
-				dis.logger.Debug("Discovery completed successfully")
+				dis.logger.Debug("discovery completed successfully")
 			}
 			dis.discoveredResourcesMu.Unlock()
 		case <-ctx.Done():
-			dis.logger.Debug("Discovery worker context done, exiting")
+			dis.logger.Debug("discovery worker context done, exiting")
 			return
 		}
 	}
@@ -301,9 +301,10 @@ func (dis *rtspDiscovery) discoveryBackgroundWorker(ctx context.Context) {
 func (dis *rtspDiscovery) Close(_ context.Context) error {
 	dis.mdnsServer.Shutdown()
 	if dis.workers != nil {
+		dis.logger.Debug("stopping discovery service workers")
 		dis.workers.Stop()
 	}
-	dis.logger.Debug("Discovery service closed")
+	dis.logger.Debug("discovery service closed")
 
 	return nil
 }

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -288,18 +288,17 @@ func (dis *rtspDiscovery) preview(ctx context.Context, rtspURL string) (string, 
 func (dis *rtspDiscovery) discoveryBackgroundWorker(ctx context.Context) {
 	ticker := time.NewTicker(discoveryInterval)
 	defer ticker.Stop()
-
 	for {
 		select {
 		case <-ticker.C:
-			if discovered, err := dis.runDiscoveryLookup(ctx, nil); err != nil {
+			discovered, err := dis.runDiscoveryLookup(ctx, nil)
+			if err != nil {
 				dis.logger.Errorf("discovery failed: %v", err)
-				dis.discoveredResourcesMu.Lock()
-				dis.discoveredResources = discovered
-				dis.discoveredResourcesMu.Unlock()
-			} else {
-				dis.logger.Debug("discovery completed successfully")
+				continue
 			}
+			dis.discoveredResourcesMu.Lock()
+			dis.discoveredResources = discovered
+			dis.discoveredResourcesMu.Unlock()
 		case <-ctx.Done():
 			dis.logger.Debug("discovery worker context done, exiting")
 			return

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -140,7 +140,7 @@ func (dis *rtspDiscovery) DiscoverResources(ctx context.Context, extra map[strin
 	// If we have previously discovered cameras, we will return the cached resources.
 	dis.discoveredResourcesMu.Lock()
 	cachedDiscovered := dis.discoveredResources
-        dis.discoveredResourcesMu.Unlock()
+	dis.discoveredResourcesMu.Unlock()
 	if len(cachedDiscovered) > 0 {
 		dis.logger.Debug("returning cached discovered resources")
 		return cachedDiscovered, nil
@@ -282,7 +282,7 @@ func (dis *rtspDiscovery) preview(ctx context.Context, rtspURL string) (string, 
 	return "", fmt.Errorf("both snapshot and RTSP fetch failed: %w", errors.Join(snapshotErr, rtspErr))
 }
 
-// discoveryBackgroundWorker loops and runs the discovery service's DiscoverResources method
+// discoveryBackgroundWorker loops and runs the discovery service's DiscoverResources method.
 func (dis *rtspDiscovery) discoveryBackgroundWorker(ctx context.Context) {
 	ticker := time.NewTicker(discoveryInterval)
 	defer ticker.Stop()
@@ -457,7 +457,7 @@ func fetchImageFromRTSPURL(ctx context.Context, logger logging.Logger, rtspURL s
 	}
 }
 
-// generateUniqueName creates a unique name by adding timestamp and random bytes
+// generateUniqueName creates a unique name by adding timestamp and random bytes.
 func generateUniqueName(prefix string) string {
 	timestamp := time.Now().UnixNano()
 	uniqueName := fmt.Sprintf("%s-%d", prefix, timestamp)

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -85,7 +85,8 @@ type rtspDiscovery struct {
 	mdnsServer  *mdnsServer
 	logger      logging.Logger
 
-	workers               *utils.StoppableWorkers
+	workers *utils.StoppableWorkers
+
 	discoveredResourcesMu sync.Mutex
 	discoveredResources   []resource.Config
 }

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -134,8 +134,8 @@ func (dis *rtspDiscovery) DiscoverResources(ctx context.Context, extra map[strin
 		}
 		return discovered, nil
 	} else if len(dis.discoveredResources) == 0 {
-		// If discovery has been run before or no cameras were discovered, we will run discovery
-		// lookup again to ensure we have the latest discovered resources.
+		// If discovery has not been run before, or no cameras were discovered,
+		// we will run discovery lookup again.
 		dis.discoveredResourcesMu.Lock()
 		defer dis.discoveredResourcesMu.Unlock()
 		dis.logger.Debug("no extra parameters provided, running discovery lookup with config credentials")

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -309,10 +309,8 @@ func (dis *rtspDiscovery) discoveryBackgroundWorker(ctx context.Context) {
 
 func (dis *rtspDiscovery) Close(_ context.Context) error {
 	dis.mdnsServer.Shutdown()
-	if dis.workers != nil {
-		dis.logger.Debug("stopping discovery service workers")
-		dis.workers.Stop()
-	}
+	dis.logger.Debug("stopping discovery service workers")
+	dis.workers.Stop()
 	dis.logger.Debug("discovery service closed")
 
 	return nil

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -127,7 +127,8 @@ func (dis *rtspDiscovery) DiscoverResources(ctx context.Context, extra map[strin
 	// If extra is not empty, we assume the user wants to discover resources
 	// with provided credentials. We ignore any previously discovered resources
 	// and re-run discovery with extra parameters.
-	if len(extra) > 0 {
+	_, hasExtraCreds := getCredFromExtra(extra)
+	if hasExtraCreds {
 		dis.logger.Debugf("running discovery lookup with extra parameters: %v", extra)
 		discovered, err := dis.runDiscoveryLookup(ctx, extra)
 		if err != nil {

--- a/viamonvif/service_test.go
+++ b/viamonvif/service_test.go
@@ -36,7 +36,7 @@ func TestDiscoveryService(t *testing.T) {
 		test.That(t, dis.Name().ShortName(), test.ShouldResemble, testName)
 		cfgs, err := dis.DiscoverResources(ctx, nil)
 		test.That(t, cfgs, test.ShouldBeEmpty)
-		test.That(t, err, test.ShouldBeError, errNoCamerasFound)
+		test.That(t, err, test.ShouldContain, errNoCamerasFound)
 	})
 }
 

--- a/viamonvif/service_test.go
+++ b/viamonvif/service_test.go
@@ -36,7 +36,7 @@ func TestDiscoveryService(t *testing.T) {
 		test.That(t, dis.Name().ShortName(), test.ShouldResemble, testName)
 		cfgs, err := dis.DiscoverResources(ctx, nil)
 		test.That(t, cfgs, test.ShouldBeEmpty)
-		test.That(t, err, test.ShouldContain, errNoCamerasFound)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errNoCamerasFound.Error())
 	})
 }
 


### PR DESCRIPTION
## Description
- Adds background worker to discover resources on an interval.
- `DiscoverResources` returns cached resources if available.


## Demo

https://github.com/user-attachments/assets/613bb99c-293a-455e-b33b-b556a6348596


## Tests

### Manual Tests
- DiscoverResources waits for results when queried shortly after boot up ✅ 
- DiscoverResources returns cached results immediately when available ✅ 
- DiscoverResource uses extra credentials when provided ✅ 

### Automated Tests
We do not have the infra test ONVIF in CI. See follow-up ticket [here](https://viam.atlassian.net/browse/RSDK-10970).

___ 

TODO:
- [x] Figure out how to test changing IP address of camera, making sure it is updated via the background poller


For reference, here is how to repro IP change on an orin-nano:
1. Run mediamtx for RTSP server
2. Run fake ffmpeg cam
```
ffmpeg -f lavfi -re -i testsrc=size=800x600:rate=30 -vf drawtext=fontfile=/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf:text='Timestamp %{localtime}':fontcolor=white:fontsize=24:x=10:y=10 -c:v libx264 -preset ultrafast -pix_fmt yuv420p -f rtsp rtsp://0.0.0.0:8554/mystream
```
3. Create fake onvif server
```
./onvif_srvd --ifs wlP1p1s0 --scope onvif://www.onvif.org/name/TestDev --scope onvif://www.onvif.org/Profile/S --name RTSP --width 800 --height 600 --url rtsp://%s:8554/mystream --type JPEG --no_chdir --serial_num fakeserialnum
```
4. Create fake WS discovery server
```
./wsdd --if_name wlP1p1s0 --type tdn:NetworkVideoTransmitter --xaddr http://%s:1000/onvif/device_service --scope onvif://www.onvif.org/name/Unknown onvif://www.onvif.org/Profile/Streaming
```
5. Change the assigned IP address:
```
ip addr flush dev wlP1p1s0
ip addr add 10.1.11.102/20 dev wlP1p1s0
```
