### PR TITLE
RSDK-11548 - Fix home path viamrtsp

### DIFF
--- a/videostore/config.go
+++ b/videostore/config.go
@@ -39,10 +39,8 @@ func applyDefaults(cfg *Config, name string) (videostore.Config, error) {
 	if fps == 0 {
 		fps = defaultFramerate
 	}
-	sc, err := applyStorageDefaults(cfg.Storage, name)
-	if err != nil {
-		return videostore.Config{}, err
-	}
+
+	sc := applyStorageDefaults(cfg.Storage, name)
 
 	ec := applyVideoEncoderDefaults(cfg.Video)
 	return videostore.Config{
@@ -68,10 +66,7 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		return nil, nil, fmt.Errorf("invalid framerate %d, must be greater than 0", cfg.Framerate)
 	}
 
-	sConfig, err := applyStorageDefaults(cfg.Storage, "someprefix")
-	if err != nil {
-		return nil, nil, err
-	}
+	sConfig := applyStorageDefaults(cfg.Storage, "someprefix")
 	if err := sConfig.Validate(); err != nil {
 		return nil, nil, err
 	}
@@ -100,7 +95,7 @@ func applyVideoEncoderDefaults(c Video) videostore.EncoderConfig {
 	}
 }
 
-func applyStorageDefaults(c Storage, name string) (videostore.StorageConfig, error) {
+func applyStorageDefaults(c Storage, name string) videostore.StorageConfig {
 	if c.UploadPath == "" {
 		home := rutils.PlatformHomeDir()
 		c.UploadPath = filepath.Join(home, defaultUploadPath, name)
@@ -114,5 +109,5 @@ func applyStorageDefaults(c Storage, name string) (videostore.StorageConfig, err
 		OutputFileNamePrefix: name,
 		UploadPath:           c.UploadPath,
 		StoragePath:          c.StoragePath,
-	}, nil
+	}
 }


### PR DESCRIPTION
## Tests


### windows/amd64, office desktop set up by Amir near where recruiters sit

viam-server 0.87.1, viam-agent 0.21.0

Started storing videos to path in `"C:\\Windows\\system32\\config\\systemprofile\\.viam\\video-storage\\<resource_name>"` on 0.4.9-rc1. When switching to this feature branch build, we continue storing on this path. 

I thought saving to system32 was a bit weird so I asked netcode about it https://viaminc.slack.com/archives/C06542APFRQ/p1754677855165559

It seems to be expected since viam agent is ran as the SYSTEM user, whose home dir is indeed in system32. 

### linux/arm64

viam-server 0.87.1, viam-agent 0.21.0

Verified path `/root/.viam/video-storage/` did not change between registry viamrtsp and feature-branch-built viamrtsp
### linux/amd64

viam-server 0.87.1, viam-agent 0.21.0

Verified path `/root/.viam/video-storage/` did not change between registry viamrtsp and feature-branch-built viamrtsp