### PR TITLE
[RSDK-11088] - Add ptz-client discovery

### DIFF
--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -72,9 +72,9 @@ type Config struct {
 	Password     string                 `json:"password"`
 	ProfileToken string                 `json:"profile_token"`
 	NodeToken    string                 `json:"ptz_node_token,omitempty"`
-	Movements    map[string]PTZMovement `json:"movements,omitempty"`     // Optional PTZ movements
-	DiscoveryDep string                 `json:"discovery_dep,omitempty"` // Optional dependency for discovery
-
+	Movements    map[string]PTZMovement `json:"movements,omitempty"`
+	DiscoveryDep string                 `json:"discovery_dep,omitempty"`
+	RTSPAddress  string                 `json:"rtsp_address,omitempty"`
 }
 
 // Validate validates the configuration for the ONVIF PTZ client.

--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -39,15 +39,6 @@ func init() {
 	)
 }
 
-// PTZCaps defines the capabilities of the ONVIF PTZ service.
-type PTZCaps struct {
-	StatusPosition              bool `json:"status_position"`
-	EFlip                       bool `json:"e_flip"`
-	Reverse                     bool `json:"reverse"`
-	GetCompatibleConfigurations bool `json:"get_compatible_configurations"`
-	MoveStatus                  bool `json:"move_status"`
-}
-
 // PanTiltSpace defines the pan and tilt space for the PTZ movement.
 type PanTiltSpace struct {
 	XMin  float64 `json:"x_min"`

--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -71,7 +71,7 @@ type Config struct {
 	Username     string                 `json:"username"`
 	Password     string                 `json:"password"`
 	ProfileToken string                 `json:"profile_token"`
-	NodeToken    string                 `json:"node_token,omitempty"`
+	NodeToken    string                 `json:"ptz_node_token,omitempty"`
 	Movements    map[string]PTZMovement `json:"movements,omitempty"`     // Optional PTZ movements
 	DiscoveryDep string                 `json:"discovery_dep,omitempty"` // Optional dependency for discovery
 

--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -39,6 +39,7 @@ func init() {
 	)
 }
 
+// PTZCaps defines the capabilities of the ONVIF PTZ service.
 type PTZCaps struct {
 	StatusPosition              bool `json:"status_position"`
 	EFlip                       bool `json:"e_flip"`
@@ -47,6 +48,7 @@ type PTZCaps struct {
 	MoveStatus                  bool `json:"move_status"`
 }
 
+// PanTiltSpace defines the pan and tilt space for the PTZ movement.
 type PanTiltSpace struct {
 	XMin  float64 `json:"x_min"`
 	XMax  float64 `json:"x_max"`
@@ -54,12 +56,15 @@ type PanTiltSpace struct {
 	YMax  float64 `json:"y_max"`
 	Space string  `json:"space"`
 }
+
+// ZoomSpace defines the zoom space for the PTZ movement.
 type ZoomSpace struct {
 	XMin  float64 `json:"x_min"`
 	XMax  float64 `json:"x_max"`
 	Space string  `json:"space"`
 }
 
+// PTZMovement defines the movement parameters for pan, tilt, and zoom.
 type PTZMovement struct {
 	PanTilt PanTiltSpace `json:"pan_tilt,omitempty"`
 	Zoom    ZoomSpace    `json:"zoom,omitempty"`

--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -39,12 +39,42 @@ func init() {
 	)
 }
 
+type PTZCaps struct {
+	StatusPosition              bool `json:"status_position"`
+	EFlip                       bool `json:"e_flip"`
+	Reverse                     bool `json:"reverse"`
+	GetCompatibleConfigurations bool `json:"get_compatible_configurations"`
+	MoveStatus                  bool `json:"move_status"`
+}
+
+type PanTiltSpace struct {
+	XMin  float64 `json:"x_min"`
+	XMax  float64 `json:"x_max"`
+	YMin  float64 `json:"y_min"`
+	YMax  float64 `json:"y_max"`
+	Space string  `json:"space"`
+}
+type ZoomSpace struct {
+	XMin  float64 `json:"x_min"`
+	XMax  float64 `json:"x_max"`
+	Space string  `json:"space"`
+}
+
+type PTZMovement struct {
+	PanTilt PanTiltSpace `json:"pan_tilt,omitempty"`
+	Zoom    ZoomSpace    `json:"zoom,omitempty"`
+}
+
 // Config represents the configuration for the ONVIF PTZ client.
 type Config struct {
-	Address      string `json:"address"`
-	Username     string `json:"username"`
-	Password     string `json:"password"`
-	ProfileToken string `json:"profile_token"`
+	Address      string                 `json:"address"`
+	Username     string                 `json:"username"`
+	Password     string                 `json:"password"`
+	ProfileToken string                 `json:"profile_token"`
+	NodeToken    string                 `json:"node_token,omitempty"`
+	Movements    map[string]PTZMovement `json:"movements,omitempty"`     // Optional PTZ movements
+	DiscoveryDep string                 `json:"discovery_dep,omitempty"` // Optional dependency for discovery
+
 }
 
 // Validate validates the configuration for the ONVIF PTZ client.

--- a/viamonvif/device/device.go
+++ b/viamonvif/device/device.go
@@ -413,3 +413,15 @@ func (dev *Device) sendSoap(ctx context.Context, endpoint, message string) ([]by
 
 	return io.ReadAll(resp.Body)
 }
+
+func (dev *Device) GetXaddr() *url.URL {
+	if dev.xaddr == nil {
+		return nil
+	}
+	// Return a copy of the xaddr to avoid external modification.
+	return &url.URL{
+		Scheme: dev.xaddr.Scheme,
+		Host:   dev.xaddr.Host,
+		Path:   dev.xaddr.Path,
+	}
+}

--- a/viamonvif/device/device.go
+++ b/viamonvif/device/device.go
@@ -427,16 +427,6 @@ func (dev *Device) GetXaddr() *url.URL {
 	}
 }
 
-// minimal envelope for decoding only the PTZNode elements.
-type getNodesEnvelope struct {
-	XMLName xml.Name `xml:"Envelope"`
-	Body    struct {
-		GetNodesResponse struct {
-			Nodes []onvif.PTZNode `xml:"PTZNode"`
-		} `xml:"GetNodesResponse"`
-	} `xml:"Body"`
-}
-
 // GetPTZNodes returns a list of PTZ nodes supported by the device.
 // Includes complete information about each node's movement capabilities.
 func (dev *Device) GetPTZNodes(ctx context.Context) ([]onvif.PTZNode, error) {
@@ -447,7 +437,7 @@ func (dev *Device) GetPTZNodes(ctx context.Context) ([]onvif.PTZNode, error) {
 	}
 	dev.logger.Debugf("GetPTZNodes response body: %s", string(data))
 
-	var env getNodesEnvelope
+	var env onvif.GetNodesEnvelope
 	if err := xml.Unmarshal(data, &env); err != nil {
 		return nil, fmt.Errorf("unmarshal GetNodesResponse: %w", err)
 	}

--- a/viamonvif/device/device.go
+++ b/viamonvif/device/device.go
@@ -415,6 +415,7 @@ func (dev *Device) sendSoap(ctx context.Context, endpoint, message string) ([]by
 	return io.ReadAll(resp.Body)
 }
 
+// GetXaddr returns the device's xaddr URL.
 func (dev *Device) GetXaddr() *url.URL {
 	if dev.xaddr == nil {
 		return nil
@@ -427,6 +428,7 @@ func (dev *Device) GetXaddr() *url.URL {
 	}
 }
 
+// GetPTZNodes retrieves the PTZ nodes from the device.
 func (dev *Device) GetPTZNodes(ctx context.Context) ([]onvif.PTZNode, error) {
 	req := ptz.GetNodes{}
 	data, err := dev.callOnvifServiceMethod(ctx, dev.endpoints["ptz"], req)

--- a/viamonvif/device/device.go
+++ b/viamonvif/device/device.go
@@ -427,7 +427,7 @@ func (dev *Device) GetXaddr() *url.URL {
 	}
 }
 
-// minimal envelope for decoding only the PTZNode elements
+// minimal envelope for decoding only the PTZNode elements.
 type getNodesEnvelope struct {
 	XMLName xml.Name `xml:"Envelope"`
 	Body    struct {

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -119,12 +119,11 @@ type MediaInfo struct {
 // PTZInfo holds detailed information about a camera's PTZ support.
 type PTZInfo struct {
 	Address      string                           `json:"address"`
-	RTSPAddress  string                           `json:"rtsp_address,omitempty"` // Optional RTSP address
+	RTSPAddress  string                           `json:"rtsp_address"`
 	Username     string                           `json:"username"`
 	Password     string                           `json:"password"`
 	ProfileToken string                           `json:"profile_token"`
 	PTZNodeToken string                           `json:"ptz_node_token"`
-	Capabilities ptzclient.PTZCaps                `json:"capabilities"`
 	Movements    map[string]ptzclient.PTZMovement `json:"movements"`
 }
 
@@ -459,7 +458,6 @@ func GetMediaInfoFromProfiles(
 			Password:     creds.Pass,
 			ProfileToken: string(profile.Token),
 			PTZNodeToken: nodeToken,
-			Capabilities: ptzclient.PTZCaps{}, // TODO: Fill this with service capabilities if needed
 			Movements:    movements,
 		})
 	}

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -116,6 +116,7 @@ type MediaInfo struct {
 	Codec       string              `json:"codec"`
 }
 
+// PTZInfo holds detailed information about a camera's PTZ support.
 type PTZInfo struct {
 	Address      string                           `json:"address"`
 	RTSPAddress  string                           `json:"rtsp_address,omitempty"` // Optional RTSP address
@@ -312,16 +313,6 @@ func GetCameraInfo(
 	}
 
 	return cameraInfo, nil
-}
-
-func ExtractInfoFromProfiles(
-	ctx context.Context,
-	dev OnvifDevice,
-	profileToken onvif.ReferenceToken,
-	logger logging.Logger,
-) ([]MediaInfo, []PTZInfo, error) {
-	// Get the media info from the profiles
-	return nil, nil, nil
 }
 
 // GetMediaInfoFromProfiles uses the ONVIF Media service to get the RTSP stream URLs

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -381,14 +381,16 @@ func GetMediaInfoFromProfiles(
 		// If we don't find a matching node, we skip this profile.
 		// This is a safeguard against cameras that return multiple nodes
 		// but only one is actually associated with the profile we're examining.
-		var selected *onvif.PTZNode
-		for i := range nodes {
-			if string(nodes[i].Token) == nodeToken {
-				selected = &nodes[i]
+		var selected onvif.PTZNode
+		ptzNodeFound := false
+		for _, node := range nodes {
+			if string(node.Token) == nodeToken {
+				selected = node
+				ptzNodeFound = true
 				break
 			}
 		}
-		if selected == nil {
+		if !ptzNodeFound {
 			logger.Debugf("PTZ node %s not found for profile %s", nodeToken, profile.Name)
 			continue
 		}

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -460,6 +460,8 @@ func GetMediaInfoFromProfiles(
 }
 
 // uriToSpaceName extracts the space name from a URI.
+// For example, given the URI "http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace",
+// it returns "PositionGenericSpace".
 func uriToSpaceName(uri string) string {
 	parts := strings.Split(uri, "/")
 	return parts[len(parts)-1]

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -186,6 +186,17 @@ func (cam *CameraInfo) tryMDNS(mdnsServer *mdnsServer, logger logging.Logger) {
 		}
 	}
 
+	// Also need to replace IP address with hostname in PTZ endpoints.
+	for idx := range cam.PTZEndpoints {
+		if strings.Contains(cam.PTZEndpoints[idx].RTSPAddress, cam.deviceIP.String()) {
+			cam.PTZEndpoints[idx].RTSPAddress = strings.Replace(cam.PTZEndpoints[idx].RTSPAddress, cam.deviceIP.String(), cam.mdnsName, 1)
+			cam.PTZEndpoints[idx].Address = strings.Replace(cam.PTZEndpoints[idx].Address, cam.deviceIP.String(), cam.mdnsName, 1)
+		} else {
+			logger.Debugf("PTZ RTSP URL did not contain expected hostname. URL: %v HostName: %v",
+				cam.PTZEndpoints[idx].RTSPAddress, cam.deviceIP.String())
+		}
+	}
+
 	if !wasIPFound {
 		// If for some reason, the `deviceIP`/`xaddr.Host` IP was not found in any of the RTSP urls,
 		// stop serving mdns requests for that serial number.

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -369,7 +369,7 @@ func GetMediaInfoFromProfiles(
 
 		nodes, err := dev.GetPTZNodes(ctx)
 		if err != nil {
-			logger.Warnf("Unable to determine onvif ptz nodes for profile %s: %s, err: %s",
+			logger.Debugf("Unable to determine onvif ptz nodes for profile %s: %s, err: %s",
 				profile.Name, streamURI.String(), err)
 			continue
 		}
@@ -386,7 +386,7 @@ func GetMediaInfoFromProfiles(
 			}
 		}
 		if selected == nil {
-			logger.Warnf("PTZ node %s not found for profile %s", nodeToken, profile.Name)
+			logger.Debugf("PTZ node %s not found for profile %s", nodeToken, profile.Name)
 			continue
 		}
 

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -377,7 +377,11 @@ func GetMediaInfoFromProfiles(
 		ptzCfg := profile.PTZConfiguration
 		nodeToken := string(ptzCfg.NodeToken)
 
-		// find the matching PTZNode
+		// Find the matching PTZNode. We only want to use the node that matches the token
+		// specified in the profile's PTZConfiguration.
+		// If we don't find a matching node, we skip this profile.
+		// This is a safeguard against cameras that return multiple nodes
+		// but only one is actually associated with the profile we're examining.
 		var selected *onvif.PTZNode
 		for i := range nodes {
 			if string(nodes[i].Token) == nodeToken {

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -216,7 +216,6 @@ func (cam *CameraInfo) urlDependsOnMDNS(idx int) bool {
 // CameraInfoList is a struct containing a list of CameraInfo structs.
 type CameraInfoList struct {
 	Cameras []CameraInfo `json:"cameras"`
-	PTZs    []PTZInfo    `json:"ptzs,omitempty"` // PTZs are optional
 }
 
 // DiscoverCameraInfo discovers camera information on a given uri
@@ -440,8 +439,13 @@ func GetMediaInfoFromProfiles(
 			movements["continuous"] = m
 		}
 
+		var host string
+		if x := dev.GetXaddr(); x != nil {
+			host = x.Host
+		}
+
 		ptzInfos = append(ptzInfos, PTZInfo{
-			Address:      dev.GetXaddr().Host,
+			Address:      host,
 			RTSPAddress:  streamURI.String(),
 			Username:     creds.User,
 			Password:     creds.Pass,

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -118,6 +118,7 @@ type MediaInfo struct {
 
 type PTZInfo struct {
 	Address      string                           `json:"address"`
+	RTSPAddress  string                           `json:"rtsp_address,omitempty"` // Optional RTSP address
 	Username     string                           `json:"username"`
 	Password     string                           `json:"password"`
 	ProfileToken string                           `json:"profile_token"`
@@ -437,6 +438,7 @@ func GetMediaInfoFromProfiles(
 
 		ptzInfos = append(ptzInfos, PTZInfo{
 			Address:      dev.GetXaddr().Host,
+			RTSPAddress:  streamURI.String(),
 			Username:     creds.User,
 			Password:     creds.Pass,
 			ProfileToken: string(profile.Token),

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -420,7 +420,9 @@ func GetMediaInfoFromProfiles(
 		}
 
 		// Build the PTZInfo with supported movements. If a movement type is not supported,
-		// it will not be included in the Movements map.
+		// it will not be included in the Movements map. Pointers are used in the helper functions
+		// to indicate whether a movement type is supported or not. Nil pointers indicate
+		// unsupported movement types.
 		movements := map[string]ptzclient.PTZMovement{}
 		if pt := make2D(selected.SupportedPTZSpaces.AbsolutePanTiltPositionSpace); pt != nil {
 			m := ptzclient.PTZMovement{PanTilt: *pt}

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -360,7 +360,7 @@ func GetMediaInfoFromProfiles(
 		})
 
 		// Check if the profile has PTZ capabilities
-		if profile.PTZConfiguration.Token == "" {
+		if profile.PTZConfiguration.NodeToken == "" {
 			logger.Debugf("Profile %s does not have PTZ capabilities, %s", profile.Name, streamURI.String())
 			continue
 		}

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -292,20 +292,20 @@ func GetCameraInfo(
 	logger.Debugf("ip: %s GetCapabilities: DeviceInfo: %#v", xaddr, dev)
 
 	// Call the ONVIF Media service to get the available media profiles using the same device instance
-	mes, pes, err := GetMediaInfoFromProfiles(ctx, dev, creds, logger)
+	mediaInfos, ptzInfos, err := GetMediaInfoFromProfiles(ctx, dev, creds, logger)
 	if err != nil {
 		return zero, fmt.Errorf("failed to get stream info: %w", err)
 	}
 
 	cameraInfo := CameraInfo{
 		Host:            xaddr.Host,
-		MediaEndpoints:  mes,
+		MediaEndpoints:  mediaInfos,
 		Manufacturer:    resp.Manufacturer,
 		Model:           resp.Model,
 		SerialNumber:    resp.SerialNumber,
 		FirmwareVersion: resp.FirmwareVersion,
 		HardwareID:      resp.HardwareID,
-		PTZEndpoints:    pes,
+		PTZEndpoints:    ptzInfos,
 
 		// Will be nil if there's an error.
 		deviceIP: net.ParseIP(xaddr.Host),
@@ -327,7 +327,7 @@ func GetMediaInfoFromProfiles(
 		return nil, nil, err
 	}
 
-	var mes []MediaInfo
+	var mediaInfos []MediaInfo
 	var ptzInfos []PTZInfo
 	// Iterate over all profiles and get the RTSP stream and snapshot URI for each one
 	for _, profile := range resp.Profiles {
@@ -347,7 +347,7 @@ func GetMediaInfoFromProfiles(
 		}
 
 		// Always add the MediaInfo if we get a stream URI, even if the snapshot URI fails.
-		mes = append(mes, MediaInfo{
+		mediaInfos = append(mediaInfos, MediaInfo{
 			StreamURI:   streamURI.String(),
 			SnapshotURI: snapshotURIString,
 			FrameRate:   int(profile.VideoEncoderConfiguration.RateControl.FrameRateLimit),
@@ -462,7 +462,7 @@ func GetMediaInfoFromProfiles(
 		})
 	}
 
-	return mes, ptzInfos, nil
+	return mediaInfos, ptzInfos, nil
 }
 
 // uriToSpaceName extracts the space name from a URI.

--- a/viamonvif/discovery.go
+++ b/viamonvif/discovery.go
@@ -444,8 +444,12 @@ func GetMediaInfoFromProfiles(
 		}
 
 		var host string
-		if x := dev.GetXaddr(); x != nil {
-			host = x.Host
+		xaddr := dev.GetXaddr()
+		if xaddr != nil {
+			host = xaddr.Host
+		} else {
+			logger.Debugf("Could not get XAddr from device, skipping the PTZ profile %s", profile.Name)
+			continue
 		}
 
 		ptzInfos = append(ptzInfos, PTZInfo{

--- a/viamonvif/discovery_test.go
+++ b/viamonvif/discovery_test.go
@@ -66,7 +66,6 @@ func (m *MockDevice) GetStreamURI(_ context.Context, token onvif.ReferenceToken,
 }
 
 func (m *MockDevice) GetPTZNodes(_ context.Context) ([]onvif.PTZNode, error) {
-	// Fill out mock PTZ nodes as needed for testing.
 	node := onvif.PTZNode{
 		DeviceEntity: onvif.DeviceEntity{
 			Token: "PTZNode1",
@@ -78,7 +77,6 @@ func (m *MockDevice) GetPTZNodes(_ context.Context) ([]onvif.PTZNode, error) {
 				XRange: onvif.FloatRange{Min: -1.0, Max: 1.0},
 				YRange: onvif.FloatRange{Min: -1.0, Max: 1.0},
 			},
-			// optional: add zoom if you need it in tests
 			ContinuousZoomVelocitySpace: onvif.Space1DDescription{
 				URI:    "http://www.onvif.org/ver10/tptz/ZoomSpaces/VelocityGenericSpace",
 				XRange: onvif.FloatRange{Min: 0.0, Max: 1.0},

--- a/viamonvif/discovery_test.go
+++ b/viamonvif/discovery_test.go
@@ -159,6 +159,10 @@ func TestGetCameraInfo(t *testing.T) {
 				test.ShouldResemble,
 				expectedMovements,
 			)
+			test.That(t, cameraInfo.PTZEndpoints[0].PTZNodeToken, test.ShouldEqual, "PTZNode1")
+			test.That(t, cameraInfo.PTZEndpoints[0].ProfileToken, test.ShouldEqual, "profile1")
+			test.That(t, cameraInfo.PTZEndpoints[0].RTSPAddress, test.ShouldEqual, "rtsp://192.168.1.100/stream")
+			test.That(t, cameraInfo.PTZEndpoints[0].Address, test.ShouldEqual, "192.168.1.100:80")
 		})
 	})
 }

--- a/viamonvif/discovery_test.go
+++ b/viamonvif/discovery_test.go
@@ -19,10 +19,35 @@ import (
 	"go.viam.com/utils"
 )
 
-type MockDevice struct{}
+type MockDevice struct {
+	GetProfilesFn    func(context.Context) (device.GetProfilesResponse, error)
+	GetPTZNodesFn    func(context.Context) ([]onvif.PTZNode, error)
+	GetStreamURIFn   func(context.Context, onvif.ReferenceToken, device.Credentials) (*url.URL, error)
+	GetSnapshotURIFn func(context.Context, onvif.ReferenceToken, device.Credentials) (*url.URL, error)
+	GetXaddrFn       func() *url.URL
+}
 
 func NewMockDevice() *MockDevice {
-	return &MockDevice{}
+	return &MockDevice{
+		GetProfilesFn: func(_ context.Context) (device.GetProfilesResponse, error) {
+			return device.GetProfilesResponse{Profiles: []onvif.Profile{
+				{Token: "profile1", Name: "Main Profile"},
+			}}, nil
+		},
+		GetPTZNodesFn: func(_ context.Context) ([]onvif.PTZNode, error) {
+			return []onvif.PTZNode{}, nil
+		},
+		GetStreamURIFn: func(_ context.Context, _ onvif.ReferenceToken, _ device.Credentials) (*url.URL, error) {
+			return url.Parse("rtsp://192.168.1.100/stream")
+		},
+		GetSnapshotURIFn: func(_ context.Context, _ onvif.ReferenceToken, _ device.Credentials) (*url.URL, error) {
+			return url.Parse("http://example.com/snapshot.jpg")
+		},
+		GetXaddrFn: func() *url.URL {
+			u, _ := url.Parse("http://192.168.1.100:80")
+			return u
+		},
+	}
 }
 
 func (m *MockDevice) GetDeviceInformation(_ context.Context) (device.GetDeviceInformationResponse, error) {
@@ -33,71 +58,45 @@ func (m *MockDevice) GetDeviceInformation(_ context.Context) (device.GetDeviceIn
 	}, nil
 }
 
-func (m *MockDevice) GetProfiles(_ context.Context) (device.GetProfilesResponse, error) {
-	return device.GetProfilesResponse{
-		Profiles: []onvif.Profile{
-			{
-				Token: "profile1",
-				Name:  "Main Profile",
-				PTZConfiguration: onvif.PTZConfiguration{
-					NodeToken: onvif.ReferenceToken("PTZNode1"),
-				},
-			},
-		},
-	}, nil
+func (m *MockDevice) GetProfiles(ctx context.Context) (device.GetProfilesResponse, error) {
+	return m.GetProfilesFn(ctx)
 }
 
-func (m *MockDevice) GetSnapshotURI(_ context.Context, _ onvif.ReferenceToken, _ device.Credentials) (*url.URL, error) {
-	return url.Parse("http://example.com/snapshot.jpg")
+func (m *MockDevice) GetSnapshotURI(ctx context.Context, token onvif.ReferenceToken, creds device.Credentials) (*url.URL, error) {
+	return m.GetSnapshotURIFn(ctx, token, creds)
 }
 
-func (m *MockDevice) GetStreamURI(_ context.Context, token onvif.ReferenceToken, creds device.Credentials) (*url.URL, error) {
-	if token != "profile1" {
-		return nil, errors.New("invalid mock profile")
-	}
-	u, err := url.Parse("rtsp://192.168.1.100/stream")
-	if err != nil {
-		return nil, err
-	}
-	if creds.User != "" || creds.Pass != "" {
-		u.User = url.UserPassword(creds.User, creds.Pass)
-	}
-	return u, nil
+func (m *MockDevice) GetStreamURI(ctx context.Context, token onvif.ReferenceToken, creds device.Credentials) (*url.URL, error) {
+	return m.GetStreamURIFn(ctx, token, creds)
 }
 
-func (m *MockDevice) GetPTZNodes(_ context.Context) ([]onvif.PTZNode, error) {
-	node := onvif.PTZNode{
-		DeviceEntity: onvif.DeviceEntity{
-			Token: "PTZNode1",
-		},
-		Name: "PTZNode1",
-		SupportedPTZSpaces: onvif.PTZSpaces{
-			ContinuousPanTiltVelocitySpace: onvif.Space2DDescription{
-				URI:    "http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace",
-				XRange: onvif.FloatRange{Min: -1.0, Max: 1.0},
-				YRange: onvif.FloatRange{Min: -1.0, Max: 1.0},
-			},
-			ContinuousZoomVelocitySpace: onvif.Space1DDescription{
-				URI:    "http://www.onvif.org/ver10/tptz/ZoomSpaces/VelocityGenericSpace",
-				XRange: onvif.FloatRange{Min: 0.0, Max: 1.0},
-			},
-		},
-	}
-	return []onvif.PTZNode{node}, nil
+func (m *MockDevice) GetPTZNodes(ctx context.Context) ([]onvif.PTZNode, error) {
+	return m.GetPTZNodesFn(ctx)
 }
 
 func (m *MockDevice) GetXaddr() *url.URL {
-	u, err := url.Parse("http://192.168.1.100:80")
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse mock device URL: %v", err))
-	}
-	return u
+	return m.GetXaddrFn()
 }
 
 func TestGetCameraInfo(t *testing.T) {
 	t.Run("GetCameraInfo", func(t *testing.T) {
-		mockDevice := &MockDevice{}
+		// mockDevice := &MockDevice{}
+		mockDevice := NewMockDevice()
 		logger := logging.NewTestLogger(t)
+
+		mockDevice.GetStreamURIFn = func(_ context.Context, token onvif.ReferenceToken, creds device.Credentials) (*url.URL, error) {
+			if token != "profile1" {
+				return nil, errors.New("invalid mock profile")
+			}
+			u, err := url.Parse("rtsp://192.168.1.100/stream")
+			if err != nil {
+				return nil, err
+			}
+			if creds.User != "" || creds.Pass != "" {
+				u.User = url.UserPassword(creds.User, creds.Pass)
+			}
+			return u, nil
+		}
 
 		uri, err := url.Parse("192.168.1.100")
 		test.That(t, err, test.ShouldBeNil)
@@ -129,7 +128,40 @@ func TestGetCameraInfo(t *testing.T) {
 			test.That(t, cameraInfo.MediaEndpoints[0].SnapshotURI, test.ShouldEqual, "http://example.com/snapshot.jpg")
 		})
 
-		t.Run("GetCameraInfo with PTZ node containing continuous movement support", func(t *testing.T) {
+		t.Run("GetCameraInfo with PTZ node containing one ptz node with continuous movement support", func(t *testing.T) {
+			mockDevice.GetProfilesFn = func(_ context.Context) (device.GetProfilesResponse, error) {
+				return device.GetProfilesResponse{
+					Profiles: []onvif.Profile{
+						{
+							Token: "profile1",
+							Name:  "Main Profile",
+							PTZConfiguration: onvif.PTZConfiguration{
+								NodeToken: onvif.ReferenceToken("PTZNode1"),
+							},
+						},
+					},
+				}, nil
+			}
+			mockDevice.GetPTZNodesFn = func(_ context.Context) ([]onvif.PTZNode, error) {
+				node := onvif.PTZNode{
+					DeviceEntity: onvif.DeviceEntity{
+						Token: "PTZNode1",
+					},
+					Name: "PTZNode1",
+					SupportedPTZSpaces: onvif.PTZSpaces{
+						ContinuousPanTiltVelocitySpace: onvif.Space2DDescription{
+							URI:    "http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace",
+							XRange: onvif.FloatRange{Min: -1.0, Max: 1.0},
+							YRange: onvif.FloatRange{Min: -1.0, Max: 1.0},
+						},
+						ContinuousZoomVelocitySpace: onvif.Space1DDescription{
+							URI:    "http://www.onvif.org/ver10/tptz/ZoomSpaces/VelocityGenericSpace",
+							XRange: onvif.FloatRange{Min: 0.0, Max: 1.0},
+						},
+					},
+				}
+				return []onvif.PTZNode{node}, nil
+			}
 			uri, err := url.Parse("192.168.1.100")
 			test.That(t, err, test.ShouldBeNil)
 			cameraInfo, err := GetCameraInfo(context.Background(), mockDevice, uri, device.Credentials{}, logger)

--- a/viamonvif/discovery_test.go
+++ b/viamonvif/discovery_test.go
@@ -61,6 +61,19 @@ func (m *MockDevice) GetStreamURI(_ context.Context, token onvif.ReferenceToken,
 	return u, nil
 }
 
+// TODO: Implement GetPTZNodes to return a list of PTZ nodes.
+func (m *MockDevice) GetPTZNodes(_ context.Context) ([]onvif.PTZNode, error) {
+	return []onvif.PTZNode{}, nil
+}
+
+func (m *MockDevice) GetXaddr() *url.URL {
+	u, err := url.Parse("http://localhost:80")
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse mock device URL: %v", err))
+	}
+	return u
+}
+
 func TestGetCameraInfo(t *testing.T) {
 	t.Run("GetCameraInfo", func(t *testing.T) {
 		mockDevice := &MockDevice{}

--- a/viamonvif/discovery_test.go
+++ b/viamonvif/discovery_test.go
@@ -128,7 +128,15 @@ func TestGetCameraInfo(t *testing.T) {
 			test.That(t, cameraInfo.MediaEndpoints[0].SnapshotURI, test.ShouldEqual, "http://example.com/snapshot.jpg")
 		})
 
-		t.Run("GetCameraInfo with PTZ node containing one ptz node with continuous movement support", func(t *testing.T) {
+		t.Run("GetCameraInfo with no PTZ nodes", func(t *testing.T) {
+			uri, err := url.Parse("192.168.1.100")
+			test.That(t, err, test.ShouldBeNil)
+			cameraInfo, err := GetCameraInfo(context.Background(), mockDevice, uri, device.Credentials{}, logger)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, len(cameraInfo.PTZEndpoints), test.ShouldEqual, 0)
+		})
+
+		t.Run("GetCameraInfo with one PTZ node with continuous movement support", func(t *testing.T) {
 			mockDevice.GetProfilesFn = func(_ context.Context) (device.GetProfilesResponse, error) {
 				return device.GetProfilesResponse{
 					Profiles: []onvif.Profile{

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -184,7 +184,7 @@ func (dis *rtspDiscovery) runDiscoveryLookup(ctx context.Context, extra map[stri
 		dis.logger.Debugf("%s %s %s", camInfo.Manufacturer, camInfo.Model, camInfo.SerialNumber)
 		// some cameras return with no urls. explicitly skipping those so the behavior is clear in the service.
 		if len(camInfo.MediaEndpoints) == 0 {
-			dis.logger.Errorf("No urls found for camera, skipping. %s %s %s",
+			dis.logger.Debugf("No urls found for camera, skipping. %s %s %s",
 				camInfo.Manufacturer, camInfo.Model, camInfo.SerialNumber)
 			continue
 		}
@@ -212,6 +212,7 @@ func (dis *rtspDiscovery) runDiscoveryLookup(ctx context.Context, extra map[stri
 
 		ptzConfigs, err := createPTZClientFromInfo(camInfo, dis.Name().ShortName(), dis.logger)
 		if err != nil {
+			dis.logger.Debugf("Failed to create PTZ client configs for camera %s: %v", camInfo.Name, err)
 			continue
 		}
 		cams = append(cams, ptzConfigs...)

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -42,9 +42,9 @@ const (
 	snapshotClientTimeout = 5 * time.Second
 	rtspPollTimeout       = 5 * time.Second
 	rtspImageInterval     = 100 * time.Millisecond
-	rtspNameSaltLength    = 4
 	discoveryInterval     = time.Minute
 	imageReqMimeType      = "image/jpeg"
+	ptzClientNamePrefix   = "ptz-client-"
 )
 
 func init() {
@@ -574,7 +574,7 @@ func createPTZClientConfig(name string, attributes ptzclient.Config) (resource.C
 	}
 
 	return resource.Config{
-		Name: "ptz-client-" + name, API: generic.API, Model: ptzclient.Model,
+		Name: ptzClientNamePrefix + name, API: generic.API, Model: ptzclient.Model,
 		Attributes: result, ConvertedAttributes: &attributes,
 	}, nil
 }

--- a/viamonvif/service.go
+++ b/viamonvif/service.go
@@ -546,6 +546,7 @@ func createPTZFromInfo(l CameraInfo, discoveryDependencyName string, logger logg
 
 		config := ptzclient.Config{
 			Address:      u.Address,
+			RTSPAddress:  u.RTSPAddress,
 			Username:     u.Username,
 			Password:     u.Password,
 			ProfileToken: u.ProfileToken,

--- a/viamonvif/xsd/onvif/onvif.go
+++ b/viamonvif/xsd/onvif/onvif.go
@@ -5,6 +5,8 @@
 package onvif
 
 import (
+	"encoding/xml"
+
 	"github.com/viam-modules/viamrtsp/viamonvif/xsd"
 )
 
@@ -932,6 +934,15 @@ type PTZSpaces struct {
 }
 
 type PTZSpacesExtension xsd.AnyType
+
+type GetNodesEnvelope struct {
+	XMLName xml.Name `xml:"Envelope"`
+	Body    struct {
+		GetNodesResponse struct {
+			Nodes []PTZNode `xml:"PTZNode"`
+		} `xml:"GetNodesResponse"`
+	} `xml:"Body"`
+}
 
 // TODO: restriction.
 type AuxiliaryData xsd.String


### PR DESCRIPTION
## Description

This PR adds ptz-client resource configs to the `onvif` model `DiscoverResources` return.

## Testing
- Reolilnk
  - DiscoverResources returns ptz-client configs for each node_token ✅ 
  - Component does not error out when added ✅ 
  - `continuous-move` DoCommands work ✅ 
```json
{
  "api": "rdk:component:generic",
  "attributes": {
    "address": "10.1.5.0:8000",
    "discovery_dep": "discovery-1",
    "movements": {
      "continuous": {
        "pan_tilt": {
          "space": "VelocityGenericSpace",
          "x_max": 1,
          "x_min": -1,
          "y_max": 1,
          "y_min": -1
        },
        "zoom": {
          "space": "VelocityGenericSpace",
          "x_max": 1,
          "x_min": -1
        }
      }
    },
    "password":  <pass>,
    "profile_token": "000",
    "ptz_node_token": "000",
    "rtsp_address": "rtsp://<user>:<pass>@10.1.5.0:554/",
    "username": <user>
  },
  "model": "viam:viamrtsp:onvif-ptz-client",
  "name": "ptz-client-REOLINK-RLC823A16X-10150-url0"
}
```
- FLIR
  - DiscoverResources returns ptz-client configs for each node_token ✅ 
  - Component does not error out when added ✅ 
  - `continuous-move` DoCommands work ✅ 
  - mDNS resolution working ✅ 
```json
{
  "api": "rdk:component:generic",
  "attributes": {
    "address": "TA0RFP6.local",
    "discovery_dep": "discovery-1",
    "movements": {
      "absolute": {
        "pan_tilt": {
          "space": "SphericalPositionSpaceDegrees",
          "x_max": 180,
          "x_min": -180,
          "y_max": 90,
          "y_min": -90
        },
        "zoom": {
          "space": "PositionGenericSpace",
          "x_max": 1,
          "x_min": 0
        }
      },
      "continuous": {
        "pan_tilt": {
          "space": "VelocityGenericSpace",
          "x_max": 1,
          "x_min": -1,
          "y_max": 1,
          "y_min": -1
        },
        "zoom": {
          "space": "VelocityGenericSpace",
          "x_max": 1,
          "x_min": -1
        }
      },
      "relative": {
        "pan_tilt": {
          "space": "SphericalTranslationSpaceDegrees",
          "x_max": 180,
          "x_min": -180,
          "y_max": 90,
          "y_min": -90
        },
        "zoom": {
          "space": "TranslationGenericSpace",
          "x_max": 1,
          "x_min": -1
        }
      }
    },
    "password": <pass>
    "profile_token": "MP0",
    "ptz_node_token": "PTZNIR0",
    "rtsp_address": "rtsp://<user>:<pass>@TA0RFP6.local:8554//ir.0",
    "username": <user>
  },
  "model": "viam:viamrtsp:onvif-ptz-client",
  "name": "ptz-client-FLIRSystems-M364C-TA0RFP6-url0"
}
```
