### PR TITLE
Add lock to sync cmds

### DIFF
--- a/examples/ptz-ctrls/client.go
+++ b/examples/ptz-ctrls/client.go
@@ -88,8 +88,8 @@ func main() {
 
 	// Map of keys to release timers
 	pressed := make(map[string]*time.Timer)
-	var mu sync.Mutex
-	var cmdMu sync.Mutex // mutex to serialize PTZ commands
+	var timerMu sync.Mutex // mutex for release timers
+	var cmdMu sync.Mutex   // mutex to serialize PTZ commands
 
 	// Duration after which we consider the key "released"
 	releaseDelay := 10 * time.Millisecond
@@ -104,8 +104,8 @@ func main() {
 	fmt.Println("Esc or Ctrl+C: Exit")
 
 	keyboard.Listen(func(key keys.Key) (stop bool, err error) {
-		mu.Lock()
-		defer mu.Unlock()
+		timerMu.Lock()
+		defer timerMu.Unlock()
 
 		keyStr := key.String() // Convert the key to a string
 		fmt.Printf("Key pressed: %s\n", keyStr)
@@ -214,8 +214,8 @@ func main() {
 
 		// Start a timer to emulate "key release"
 		pressed[keyStr] = time.AfterFunc(releaseDelay, func() {
-			mu.Lock()
-			defer mu.Unlock()
+			timerMu.Lock()
+			defer timerMu.Unlock()
 			delete(pressed, keyStr)
 
 			// Send stop command after key release


### PR DESCRIPTION
## Description

Currently, the`continuous-move` & `stop` do-command hit order is not reliable. We need to lock and synchronize cmds to make sure stop hits after move.

## Testing

Verified ordering is not an issue with aggressive 10ms releaseDelay ✅ 

```
8/22/2025, 11:51:41 AM info viam_viamrtsp.rdk:component:generic/ptz-1     ptzclient/client.go:230 Sending Stop command (PanTilt: true, Zoom: true) for profile MP0...   log_ts 2025-08-22T15:51:41.031Z

8/22/2025, 11:51:40 AM info viam_viamrtsp.rdk:component:generic/ptz-1     ptzclient/client.go:278 Sending ContinuousMove (PanSpeed: 0.00, TiltSpeed: 0.50, ZoomSpeed: 0.00) for profile MP0...   log_ts 2025-08-22T15:51:40.971Z
```