### PR TITLE
Allow unauthenticated ptz clients

### DIFF
--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -64,8 +64,8 @@ type PTZMovement struct {
 // Config represents the configuration for the ONVIF PTZ client.
 type Config struct {
 	Address      string                 `json:"address"`
-	Username     string                 `json:"username"`
-	Password     string                 `json:"password"`
+	Username     string                 `json:"username,omitempty"`
+	Password     string                 `json:"password,omitempty"`
 	ProfileToken string                 `json:"profile_token"`
 	NodeToken    string                 `json:"ptz_node_token,omitempty"`
 	Movements    map[string]PTZMovement `json:"movements,omitempty"`
@@ -79,12 +79,6 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		return nil, nil, fmt.Errorf(`expected "address" attribute for %s %q`, Model.String(), path)
 	}
 
-	if cfg.Username == "" {
-		return nil, nil, fmt.Errorf(`expected "username" attribute for %s %q`, Model.String(), path)
-	}
-	if cfg.Password == "" {
-		return nil, nil, fmt.Errorf(`expected "password" attribute for %s %q`, Model.String(), path)
-	}
 	return nil, nil, nil
 }
 
@@ -125,11 +119,15 @@ func NewClient(
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	logger.Debugf("Attempting to connect to ONVIF device at %s", conf.Address)
-	dev, err := onvif.NewDevice(onvif.DeviceParams{
-		Xaddr:    conf.Address,
-		Username: conf.Username,
-		Password: conf.Password,
-	})
+	// build device parameters, credentials are optional for unauthenticated cameras
+	params := onvif.DeviceParams{Xaddr: conf.Address}
+	if conf.Username != "" {
+		params.Username = conf.Username
+	}
+	if conf.Password != "" {
+		params.Password = conf.Password
+	}
+	dev, err := onvif.NewDevice(params)
 	if err != nil {
 		cancelFunc()
 		return nil, fmt.Errorf("failed to create ONVIF device for %s: %w", conf.Address, err)

--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -119,8 +119,8 @@ func NewClient(
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	logger.Debugf("Attempting to connect to ONVIF device at %s", conf.Address)
-	// build device parameters, credentials are optional for unauthenticated cameras
 	params := onvif.DeviceParams{Xaddr: conf.Address}
+	// Credentials are optional for unauthenticated cameras
 	if conf.Username != "" {
 		params.Username = conf.Username
 	}


### PR DESCRIPTION
## Description
There is no guarantee that the onvif server for a ptz camera is authenticated, this PR simply removes username and password validation.

## Testing

Tested that the following Amcrest camera ptz-client (which is unauthenticated but returns ptz profile) no longer errors out with empty username and password ✅ 
```
{
  "api": "rdk:component:generic",
  "attributes": {
    "address": "EF00000005087E34.local",
    "discovery_dep": "discovery-1",
    "movements": {
      "absolute": {
        "pan_tilt": {
          "space": "PositionGenericSpace",
          "x_max": 1,
          "x_min": -1,
          "y_max": 1,
          "y_min": -1
        },
        "zoom": {
          "space": "PositionGenericSpace",
          "x_max": 1,
          "x_min": -1
        }
      },
      "continuous": {
        "pan_tilt": {
          "space": "VelocityGenericSpace",
          "x_max": 1,
          "x_min": -1,
          "y_max": 1,
          "y_min": -1
        },
        "zoom": {
          "space": "VelocityGenericSpace",
          "x_max": 1,
          "x_min": -1
        }
      },
      "relative": {
        "pan_tilt": {
          "space": "TranslationGenericSpace",
          "x_max": 1,
          "x_min": -1,
          "y_max": 1,
          "y_min": -1
        },
        "zoom": {
          "space": "TranslationGenericSpace",
          "x_max": 1,
          "x_min": -1
        }
      }
    },
    "profile_token": "MainStream",
    "ptz_node_token": "ptz0",
    "rtsp_address": "rtsp://EF00000005087E34.local:554/stream0?username=admin&password=E10ADC3949BA59ABBE56E057F20F883E"
  },
  "model": "viam:viamrtsp:onvif-ptz-client",
  "name": "ptz-client-ONVIFICAMERA-F26CIRc3-EF00000005087E34-url0"
}
```

Tested with Flir cam that authenticated cams still work ✅ 

```
{
  "password": "C<N<Yk5thFsg",
  "profile_token": "MP0",
  "ptz_node_token": "PTZNIR0",
  "rtsp_address": "rtsp://admin:C%3CN%3CYk5thFsg@TA0RFP6.local:8554//ir.0",
  "username": "admin",
  "address": "TA0RFP6.local",
  "discovery_dep": "discovery-1",
  "movements": {
    "relative": {
      "pan_tilt": {
        "y_min": -90,
        "space": "SphericalTranslationSpaceDegrees",
        "x_max": 180,
        "x_min": -180,
        "y_max": 90
      },
      "zoom": {
        "x_max": 1,
        "x_min": -1,
        "space": "TranslationGenericSpace"
      }
    },
    "absolute": {
      "pan_tilt": {
        "y_max": 90,
        "y_min": -90,
        "space": "SphericalPositionSpaceDegrees",
        "x_max": 180,
        "x_min": -180
      },
      "zoom": {
        "x_max": 1,
        "x_min": 0,
        "space": "PositionGenericSpace"
      }
    },
    "continuous": {
      "zoom": {
        "x_max": 1,
        "x_min": -1,
        "space": "VelocityGenericSpace"
      },
      "pan_tilt": {
        "x_min": -1,
        "y_max": 1,
        "y_min": -1,
        "space": "VelocityGenericSpace",
        "x_max": 1
      }
    }
  }
}
```