### PR TITLE
RSDK-11889 - Add max timeout value to continuous move

### DIFF
--- a/ptzclient/client.go
+++ b/ptzclient/client.go
@@ -24,7 +24,7 @@ const (
 	defaultPanSpeed              = 0.5
 	defaultTiltSpeed             = 0.5
 	defaultZoomSpeed             = 0.5
-	defaultContinuousZoomTimeout = "PT10S"
+	maxContinuousMovementTimeout = "PT10S"
 )
 
 // Model is the model for the ONVIF PTZ client.
@@ -296,7 +296,7 @@ func (s *onvifPtzClient) handleContinuousMove(cmd map[string]interface{}) (map[s
 				Space: ContinuousZoomVelocityGenericSpace,
 			},
 		},
-		Timeout: xsd.Duration(defaultContinuousZoomTimeout),
+		Timeout: xsd.Duration(maxContinuousMovementTimeout),
 	}
 
 	s.logger.Debugf(


### PR DESCRIPTION
## Description

Currently, we do not fill out the Timeout value for continuous movements. Most cameras interpret the 0.0 default timeout value as "do not timeout until stop command is received." We ran into an issue where an ONVIF ptz service was interpreting this value literally resulting in movement commands timing out immediately.


This PR simply introduces a max 10 second timeout, which can still be preempted by a stop command. This will also ensure that no PTZ cameras get stuck in movements indefinitely.

## Testing

- Stop commands can preempt timeout value from initial move call ✅ 
- Fixes ptz controls using Dahua  camera ✅ 
- Tested dispatching continuous-move command manually ✅ 
- Tested ptz controls from specter mobile app ✅ 

https://github.com/user-attachments/assets/18b46e9d-3e96-4054-834d-1eaa35b6c396
