### PR TITLE
RSDK-13607 — Send RTCP PLI on subscribe to reduce time to first frame

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/icholy/digest v1.1.0
 	github.com/koron/go-ssdp v0.0.4
+	github.com/pion/rtcp v1.2.16
 	github.com/pion/rtp v1.8.26
 	github.com/rhysd/actionlint v1.7.8
 	github.com/stretchr/testify v1.11.1
@@ -176,7 +177,6 @@ require (
 	github.com/pion/mdns/v2 v2.1.0 // indirect
 	github.com/pion/mediadevices v0.9.0 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
-	github.com/pion/rtcp v1.2.16 // indirect
 	github.com/pion/sctp v1.8.41 // indirect
 	github.com/pion/sdp/v3 v3.0.16 // indirect
 	github.com/pion/srtp/v2 v2.0.20 // indirect

--- a/rtsp.go
+++ b/rtsp.go
@@ -215,7 +215,7 @@ type rtspCamera struct {
 	au           [][]byte
 	client       *gortsplib.Client
 	rawDecoder   *decoder
-	// h264Media is the RTSP media track for H264, used to send RTCP FIR requests to the camera.
+	// h264Media is the RTSP media track for H264.
 	h264Media *description.Media
 	// firSeqNum is the monotonically increasing sequence number for RTCP FIR requests (RFC 5104).
 	// Accessed atomically.
@@ -254,9 +254,6 @@ type rtspCamera struct {
 
 	subsMu       sync.RWMutex
 	bufAndCBByID map[rtppassthrough.SubscriptionID]bufAndCB
-
-	// h264Media is the RTSP media track for H264, used to send RTCP PLI requests to the camera.
-	h264Media *description.Media
 
 	name resource.Name
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -446,17 +446,6 @@ func (rc *rtspCamera) reconnectClient(codecInfo videoCodec, transport *gortsplib
 	}
 	clientSuccessful = true
 	rc.currentCodec.Store(int64(codecInfo))
-
-	// Send PLI after reconnect so any active passthrough subscribers receive a keyframe quickly.
-	if rc.h264Media != nil {
-		if err := rc.client.WritePacketRTCP(rc.h264Media, &rtcp.PictureLossIndication{
-			SenderSSRC: 0,
-			MediaSSRC:  0,
-		}); err != nil {
-			rc.logger.Debugw("failed to send RTCP PLI on reconnect", "err", err)
-		}
-	}
-
 	// if after reconnecting we no longer support rtp_passthrough
 	// terminate all subscription
 	// otherwise, let any remaining subscriptions continue

--- a/rtsp.go
+++ b/rtsp.go
@@ -1074,11 +1074,14 @@ func (rc *rtspCamera) SubscribeRTP(
 	rc.closeMu.RUnlock()
 
 	if client != nil && media != nil {
+		//nolint:gosec // FIR seq is uint8 per RFC 5104; wrapping at 256 is intentional.
+		nextSeq := uint8(rc.firSeqNum.Load() + 1)
 		if err := client.WritePacketRTCP(media, &rtcp.FullIntraRequest{
-			//nolint:gosec // FIR seq is uint8 per RFC 5104; wrapping at 256 is intentional.
-			FIR: []rtcp.FIREntry{{SequenceNumber: uint8(rc.firSeqNum.Add(1))}},
+			FIR: []rtcp.FIREntry{{SequenceNumber: nextSeq}},
 		}); err != nil {
 			rc.logger.Debugw("failed to send RTCP FIR on subscribe", "err", err)
+		} else {
+			rc.firSeqNum.Store(uint32(nextSeq))
 		}
 	}
 	return sub, nil

--- a/rtsp.go
+++ b/rtsp.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
 	"github.com/bluenviron/mediacommon/pkg/codecs/h265"
 	"github.com/erh/viamupnp"
+	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 	"github.com/viam-modules/viamrtsp/formatprocessor"
 	"github.com/viam-modules/viamrtsp/registry"
@@ -214,6 +215,11 @@ type rtspCamera struct {
 	au           [][]byte
 	client       *gortsplib.Client
 	rawDecoder   *decoder
+	// h264Media is the RTSP media track for H264, used to send RTCP FIR requests to the camera.
+	h264Media *description.Media
+	// firSeqNum is the monotonically increasing sequence number for RTCP FIR requests (RFC 5104).
+	// Accessed atomically.
+	firSeqNum atomic.Uint32
 
 	cancelCtx  context.Context
 	cancelFunc context.CancelFunc
@@ -326,6 +332,7 @@ func (rc *rtspCamera) closeConnection() {
 		rc.client.Close()
 		rc.client = nil
 	}
+	rc.h264Media = nil
 	rc.resetLazyAU([][]byte{})
 	rc.currentCodec.Store(0)
 	if rc.rawDecoder != nil {
@@ -500,6 +507,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		}
 		return errors.New("h264 track not found")
 	}
+	rc.h264Media = media
 
 	// setup RTP/H264 -> H264 decoder
 	rtpDec, err := f.CreateDecoder()
@@ -1049,14 +1057,30 @@ func (rc *rtspCamera) SubscribeRTP(
 	}
 
 	rc.subsMu.Lock()
-	defer rc.subsMu.Unlock()
-
 	rc.bufAndCBByID[sub.ID] = bufAndCB{
 		cb:  unitSubscriberFunc,
 		buf: buf,
 	}
 	buf.Start()
 	g.Success()
+	rc.subsMu.Unlock()
+
+	// Send an RTCP FIR to request an IDR keyframe from the camera so the new subscriber
+	// receives a decodable frame immediately. This is best-effort: if the camera ignores FIR
+	// or the client is mid-reconnect, the subscriber will receive an IDR naturally.
+	rc.closeMu.RLock()
+	client := rc.client
+	media := rc.h264Media
+	rc.closeMu.RUnlock()
+
+	if client != nil && media != nil {
+		if err := client.WritePacketRTCP(media, &rtcp.FullIntraRequest{
+			//nolint:gosec // FIR seq is uint8 per RFC 5104; wrapping at 256 is intentional.
+			FIR: []rtcp.FIREntry{{SequenceNumber: uint8(rc.firSeqNum.Add(1))}},
+		}); err != nil {
+			rc.logger.Debugw("failed to send RTCP FIR on subscribe", "err", err)
+		}
+	}
 	return sub, nil
 }
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -255,10 +255,7 @@ type rtspCamera struct {
 	subsMu       sync.RWMutex
 	bufAndCBByID map[rtppassthrough.SubscriptionID]bufAndCB
 
-	// h264Media is the RTSP media track for H264, stored during initH264 so that
-	// SubscribeRTP and reconnectClient can send RTCP PLI requests to the camera.
-	// Written only by initH264 (called from reconnectClient, single-threaded per reconnect).
-	// Cleared by closeConnection. Read under closeMu.RLock() in SubscribeRTP.
+	// h264Media is the RTSP media track for H264, used to send RTCP PLI requests to the camera.
 	h264Media *description.Media
 
 	name resource.Name
@@ -450,9 +447,7 @@ func (rc *rtspCamera) reconnectClient(codecInfo videoCodec, transport *gortsplib
 	clientSuccessful = true
 	rc.currentCodec.Store(int64(codecInfo))
 
-	// Send PLI after reconnect so any active passthrough subscribers receive a keyframe
-	// quickly rather than waiting for the camera's natural keyframe interval.
-	// rc.client and rc.h264Media were just assigned above in this goroutine — no lock needed.
+	// Send PLI after reconnect so any active passthrough subscribers receive a keyframe quickly.
 	if rc.h264Media != nil {
 		if err := rc.client.WritePacketRTCP(rc.h264Media, &rtcp.PictureLossIndication{
 			SenderSSRC: 0,

--- a/rtsp.go
+++ b/rtsp.go
@@ -255,6 +255,12 @@ type rtspCamera struct {
 	subsMu       sync.RWMutex
 	bufAndCBByID map[rtppassthrough.SubscriptionID]bufAndCB
 
+	// h264Media is the RTSP media track for H264, stored during initH264 so that
+	// SubscribeRTP and reconnectClient can send RTCP PLI requests to the camera.
+	// Written only by initH264 (called from reconnectClient, single-threaded per reconnect).
+	// Cleared by closeConnection. Read under closeMu.RLock() in SubscribeRTP.
+	h264Media *description.Media
+
 	name resource.Name
 
 	preferredTransports []*gortsplib.Transport
@@ -443,6 +449,19 @@ func (rc *rtspCamera) reconnectClient(codecInfo videoCodec, transport *gortsplib
 	}
 	clientSuccessful = true
 	rc.currentCodec.Store(int64(codecInfo))
+
+	// Send PLI after reconnect so any active passthrough subscribers receive a keyframe
+	// quickly rather than waiting for the camera's natural keyframe interval.
+	// rc.client and rc.h264Media were just assigned above in this goroutine — no lock needed.
+	if rc.h264Media != nil {
+		if err := rc.client.WritePacketRTCP(rc.h264Media, &rtcp.PictureLossIndication{
+			SenderSSRC: 0,
+			MediaSSRC:  0,
+		}); err != nil {
+			rc.logger.Debugw("failed to send RTCP PLI on reconnect", "err", err)
+		}
+	}
+
 	// if after reconnecting we no longer support rtp_passthrough
 	// terminate all subscription
 	// otherwise, let any remaining subscriptions continue
@@ -1065,9 +1084,15 @@ func (rc *rtspCamera) SubscribeRTP(
 	g.Success()
 	rc.subsMu.Unlock()
 
-	// Send an RTCP FIR to request an IDR keyframe from the camera so the new subscriber
-	// receives a decodable frame immediately. This is best-effort: if the camera ignores FIR
-	// or the client is mid-reconnect, the subscriber will receive an IDR naturally.
+	// Send RTCP FIR and PLI to request an IDR keyframe from the camera so the new subscriber
+	// receives a decodable frame immediately. Some cameras respond to FIR (RFC 5104) but not
+	// PLI (RFC 4585), or vice versa, so we send both.
+	//
+	// Lock ordering: Close() acquires closeMu then subsMu; we must not hold subsMu while
+	// acquiring closeMu, so these are sent after subsMu is released above.
+	//
+	// This is best-effort: if the camera ignores both or the client is mid-reconnect,
+	// the subscriber will receive an IDR naturally.
 	rc.closeMu.RLock()
 	client := rc.client
 	media := rc.h264Media
@@ -1082,6 +1107,12 @@ func (rc *rtspCamera) SubscribeRTP(
 			rc.logger.Debugw("failed to send RTCP FIR on subscribe", "err", err)
 		} else {
 			rc.firSeqNum.Store(uint32(nextSeq))
+		}
+		if err := client.WritePacketRTCP(media, &rtcp.PictureLossIndication{
+			SenderSSRC: 0,
+			MediaSSRC:  0,
+		}); err != nil {
+			rc.logger.Debugw("failed to send RTCP PLI on subscribe", "err", err)
 		}
 	}
 	return sub, nil


### PR DESCRIPTION
# Summary

Review #200 before this. This is a stacked PR that also adds RTCP PLI on top of FIR. 

Eliot surfaced that certain camera live streams take a long time to connect. I've observed that RTSP cameras with passthrough on can take up to 10 seconds to connect at times. This slowdown is due to the client subscribing to the stream between IDR key frames, having to wait for the next one to be able to start the video.

This PR sends an RTCP PLI (Picture Loss Indication) to the RTSP camera immediately when a new WebRTC subscriber calls `SubscribeRTP`. This requests an IDR keyframe from the camera so the subscriber receives a decodable frame quickly, rather than waiting for the camera's natural keyframe interval.

# Manual Tests

## Programmatic Tests with Local Web App TTFF Profiling

*Machine:* `sensing-framework` (linux/amd64), viam-server `v0.116.0`, viamrtsp built and hot-reloaded from `feat/rtcp-pli-on-subscribe`
*Camera:* `rtsp-1` (1280×960 H264 RTSP, rtp_passthrough enabled) with address `"rtsp://<user>:<pass>@10.1.11.241:554/cam/realmonitor?channel=1&subtype=0&unicast=true&proto=Onvif"` to the Amcrest camera in the office.
*Methodology:* Cold-start profiling: viam-server restarted between each run to clear GoStream cache and force a fresh passthrough subscription. Client TTFF (time to first frame) measured via local `webrtc-stats` [app](https://github.com/hexbabe/sensing-canary/tree/main/webrtc-stats) (headless Puppeteer, `canary-server.js`).

### __Without PLI 5 runs:__

*1*
• Client TTFF: 7785ms

*2*
• Client TTFF: 7798ms

*3*
• Client TTFF: 4314ms

*4*
• Client TTFF: 4282ms

*5*
• Client TTFF: 3735ms

### __With PLI 8 runs:__

*1*
• Client TTFF: 275ms

*2*
• Client TTFF: 141ms

*3*
• Client TTFF: 159ms

*4*
• Client TTFF: 406ms

*5*
• Client TTFF: 188ms

*6*
• Client TTFF: 149ms

*7*
• Client TTFF: 245ms

*8*
• Client TTFF: 188ms

## Qualitative Tests using app.viam.com
Without PLI: https://www.loom.com/share/b283980639f549d79493f7e9ffed25a7
With PLI: https://www.loom.com/share/6637c13cfefc4784b6717ccb16423a21

# PR Process

2 reviewers please