### PR TITLE
RSDK-13607 — Send RTCP FIR on subscribe to reduce time to first frame 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/icholy/digest v1.1.0
 	github.com/koron/go-ssdp v0.0.4
+	github.com/pion/rtcp v1.2.16
 	github.com/pion/rtp v1.8.26
 	github.com/rhysd/actionlint v1.7.8
 	github.com/stretchr/testify v1.11.1
@@ -176,7 +177,6 @@ require (
 	github.com/pion/mdns/v2 v2.1.0 // indirect
 	github.com/pion/mediadevices v0.9.0 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
-	github.com/pion/rtcp v1.2.16 // indirect
 	github.com/pion/sctp v1.8.41 // indirect
 	github.com/pion/sdp/v3 v3.0.16 // indirect
 	github.com/pion/srtp/v2 v2.0.20 // indirect

--- a/rtsp.go
+++ b/rtsp.go
@@ -215,10 +215,9 @@ type rtspCamera struct {
 	au           [][]byte
 	client       *gortsplib.Client
 	rawDecoder   *decoder
-	// h264Media is the RTSP media track for H264, used to send RTCP FIR requests to the camera.
+	// h264Media is the RTSP media track for H264.
 	h264Media *description.Media
-	// firSeqNum is the monotonically increasing sequence number for RTCP FIR requests (RFC 5104).
-	// Accessed atomically.
+	// firSeqNum holds the last FIR sequence number (0–255), wraps per RFC 5104.
 	firSeqNum atomic.Uint32
 
 	cancelCtx  context.Context

--- a/rtsp.go
+++ b/rtsp.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
 	"github.com/bluenviron/mediacommon/pkg/codecs/h265"
 	"github.com/erh/viamupnp"
+	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 	"github.com/viam-modules/viamrtsp/formatprocessor"
 	"github.com/viam-modules/viamrtsp/registry"
@@ -214,6 +215,11 @@ type rtspCamera struct {
 	au           [][]byte
 	client       *gortsplib.Client
 	rawDecoder   *decoder
+	// h264Media is the RTSP media track for H264, used to send RTCP FIR requests to the camera.
+	h264Media *description.Media
+	// firSeqNum is the monotonically increasing sequence number for RTCP FIR requests (RFC 5104).
+	// Accessed atomically.
+	firSeqNum atomic.Uint32
 
 	cancelCtx  context.Context
 	cancelFunc context.CancelFunc
@@ -326,6 +332,7 @@ func (rc *rtspCamera) closeConnection() {
 		rc.client.Close()
 		rc.client = nil
 	}
+	rc.h264Media = nil
 	rc.resetLazyAU([][]byte{})
 	rc.currentCodec.Store(0)
 	if rc.rawDecoder != nil {
@@ -500,6 +507,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		}
 		return errors.New("h264 track not found")
 	}
+	rc.h264Media = media
 
 	// setup RTP/H264 -> H264 decoder
 	rtpDec, err := f.CreateDecoder()
@@ -1056,14 +1064,30 @@ func (rc *rtspCamera) SubscribeRTP(
 	}
 
 	rc.subsMu.Lock()
-	defer rc.subsMu.Unlock()
-
 	rc.bufAndCBByID[sub.ID] = bufAndCB{
 		cb:  unitSubscriberFunc,
 		buf: buf,
 	}
 	buf.Start()
 	g.Success()
+	rc.subsMu.Unlock()
+
+	// Send an RTCP FIR to request an IDR keyframe from the camera so the new subscriber
+	// receives a decodable frame immediately. This is best-effort: if the camera ignores FIR
+	// or the client is mid-reconnect, the subscriber will receive an IDR naturally.
+	rc.closeMu.RLock()
+	client := rc.client
+	media := rc.h264Media
+	rc.closeMu.RUnlock()
+
+	if client != nil && media != nil {
+		if err := client.WritePacketRTCP(media, &rtcp.FullIntraRequest{
+			//nolint:gosec // FIR seq is uint8 per RFC 5104; wrapping at 256 is intentional.
+			FIR: []rtcp.FIREntry{{SequenceNumber: uint8(rc.firSeqNum.Add(1))}},
+		}); err != nil {
+			rc.logger.Debugw("failed to send RTCP FIR on subscribe", "err", err)
+		}
+	}
 	return sub, nil
 }
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -364,6 +364,9 @@ func (rc *rtspCamera) reconnectClientWithFallbackTransports(codecInfo videoCodec
 func (rc *rtspCamera) reconnectClient(codecInfo videoCodec, transport *gortsplib.Transport) error {
 	rc.logger.Warnf("reconnectClient called with codec: %s and transport: %s", codecInfo, transport.String())
 
+	rc.closeMu.Lock()
+	defer rc.closeMu.Unlock()
+
 	rc.closeConnection()
 
 	// replace the client with a new one, but close it if setup is not successful

--- a/rtsp.go
+++ b/rtsp.go
@@ -1029,7 +1029,7 @@ func (rc *rtspCamera) SubscribeRTP(
 
 		if !gotFirstIDR && h264.IDRPresent(tunit.AU) {
 			gotFirstIDR = true
-			rc.logger.Debugw("pre-RTCP: first IDR frame received after SubscribeRTP", "elapsed", time.Since(subscribeTime).String())
+			rc.logger.Debugw("post-RTCP-FIR: first IDR frame received after SubscribeRTP", "elapsed", time.Since(subscribeTime).String())
 		}
 
 		if !firstReceived {


### PR DESCRIPTION
This PR is the same as #199 but without PLI. #197 is stacked on top of this branch.

# Manual Tests
The Amcrest responds to FIR. Getting much better first IDR frame profiles and better TTFF overall.
```
3/17/2026, 2:37:23 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 569.207319ms  log_ts 2026-03-17T18:37:23.218Z

3/17/2026, 2:37:15 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 366.259439ms  log_ts 2026-03-17T18:37:15.840Z

3/17/2026, 2:37:00 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 440.451368ms  log_ts 2026-03-17T18:37:00.995Z

3/17/2026, 2:36:51 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 686.489129ms  log_ts 2026-03-17T18:36:51.866Z

3/17/2026, 2:36:42 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 1.166140677s  log_ts 2026-03-17T18:36:42.541Z

3/17/2026, 2:36:36 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 246.629457ms  log_ts 2026-03-17T18:36:36.784Z

3/17/2026, 2:36:31 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 158.793513ms  log_ts 2026-03-17T18:36:31.341Z

3/17/2026, 2:36:23 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 462.76143ms  log_ts 2026-03-17T18:36:23.741Z

3/17/2026, 2:36:03 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 948.348142ms  log_ts 2026-03-17T18:36:03.335Z

3/17/2026, 2:35:52 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 351.62657ms  log_ts 2026-03-17T18:35:52.720Z

3/17/2026, 2:35:47 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 173.623476ms  log_ts 2026-03-17T18:35:47.568Z

3/17/2026, 2:35:36 PM info viam_viamrtsp.rdk:component:camera/rtsp-1     project/rtsp.go:1027 first IDR frame received after SubscribeRTP   elapsed 59.873821ms  log_ts 2026-03-17T18:35:36.899Z
```

Before merging remember to rebase on main after #202 is merged, and then change the log to indicate that this is after the FIR change.

Update: Done^

# PR Process
2 reviewers