### PR TITLE
Whitelist benchmark IP range

### DIFF
--- a/viamonvif/discovery_test.go
+++ b/viamonvif/discovery_test.go
@@ -446,6 +446,10 @@ func TestIsLocalIP(t *testing.T) {
 	test.That(t, isLocalIP(net.ParseIP("10.0.0.1")), test.ShouldBeTrue)
 	test.That(t, isLocalIP(net.ParseIP("::1")), test.ShouldBeTrue)     // ipv6 loopback
 	test.That(t, isLocalIP(net.ParseIP("fc00::1")), test.ShouldBeTrue) // ipv6 private
+	test.That(t, isLocalIP(net.ParseIP("198.18.0.1")), test.ShouldBeTrue)
+	test.That(t, isLocalIP(net.ParseIP("198.19.255.254")), test.ShouldBeTrue)
+	test.That(t, isLocalIP(net.ParseIP("198.17.255.255")), test.ShouldBeFalse)
+	test.That(t, isLocalIP(net.ParseIP("198.20.0.0")), test.ShouldBeFalse)
 	test.That(t, isLocalIP(net.ParseIP("8.8.8.8")), test.ShouldBeFalse)
 	test.That(t, isLocalIP(net.ParseIP("112.112.220.108")), test.ShouldBeFalse)
 	test.That(t, isLocalIP(net.ParseIP("2607:f8b0:4004:800::200e")), test.ShouldBeFalse)

--- a/viamonvif/wsdiscovery.go
+++ b/viamonvif/wsdiscovery.go
@@ -13,16 +13,13 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// rfc2544BenchmarkNet is 198.18.0.0/15, reserved by RFC 2544 for benchmark
-// testing. It is not globally routable, and some vendors (notably Raymarine
-// marine networks) use it as the LAN range for their devices, so we treat it
-// as local for ONVIF discovery purposes.
+// rfc2544BenchmarkNet is 198.18.0.0/15, reserved for benchmark testing and
+// not globally routable. Some vendors (notably Raymarine) repurpose it as a
+// LAN range, so we treat it as local for discovery.
 var rfc2544BenchmarkNet = &net.IPNet{IP: net.IPv4(198, 18, 0, 0), Mask: net.CIDRMask(15, 32)}
 
-// isLocalIP checks if the given IP address is a local/private network address.
-// This includes RFC 1918 private ranges (10.x, 172.16-31.x, 192.168.x, fc00::/7),
-// loopback (127.x, ::1), and the RFC 2544 benchmark range (198.18.0.0/15) which
-// is non-globally-routable and used as a LAN range by some vendors.
+// isLocalIP reports whether ip is reachable on a local network — RFC 1918
+// private, loopback, or the RFC 2544 benchmark range.
 func isLocalIP(ip net.IP) bool {
 	return ip.IsPrivate() || ip.IsLoopback() || rfc2544BenchmarkNet.Contains(ip)
 }

--- a/viamonvif/wsdiscovery.go
+++ b/viamonvif/wsdiscovery.go
@@ -13,10 +13,18 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
+// rfc2544BenchmarkNet is 198.18.0.0/15, reserved by RFC 2544 for benchmark
+// testing. It is not globally routable, and some vendors (notably Raymarine
+// marine networks) use it as the LAN range for their devices, so we treat it
+// as local for ONVIF discovery purposes.
+var rfc2544BenchmarkNet = &net.IPNet{IP: net.IPv4(198, 18, 0, 0), Mask: net.CIDRMask(15, 32)}
+
 // isLocalIP checks if the given IP address is a local/private network address.
-// This includes private ranges (10.x, 172.16-31.x, 192.168.x, fc00::/7) and loopback (127.x, ::1).
+// This includes RFC 1918 private ranges (10.x, 172.16-31.x, 192.168.x, fc00::/7),
+// loopback (127.x, ::1), and the RFC 2544 benchmark range (198.18.0.0/15) which
+// is non-globally-routable and used as a LAN range by some vendors.
 func isLocalIP(ip net.IP) bool {
-	return ip.IsPrivate() || ip.IsLoopback()
+	return ip.IsPrivate() || ip.IsLoopback() || rfc2544BenchmarkNet.Contains(ip)
 }
 
 // WSDiscovery runs WS-Discovery on the network interface.

--- a/viamonvif/wsdiscovery.go
+++ b/viamonvif/wsdiscovery.go
@@ -16,6 +16,8 @@ import (
 // rfc2544BenchmarkNet is 198.18.0.0/15, reserved for benchmark testing and
 // not globally routable. Some vendors (notably Raymarine) repurpose it as a
 // LAN range, so we treat it as local for discovery.
+//
+//nolint:mnd // literal RFC 2544 reservation
 var rfc2544BenchmarkNet = &net.IPNet{IP: net.IPv4(198, 18, 0, 0), Mask: net.CIDRMask(15, 32)}
 
 // isLocalIP reports whether ip is reachable on a local network — RFC 1918


### PR DESCRIPTION
## Description

Quick patch to whitelist the benchmark IP address range. This range is used by Raymarine MFD and cameras.

[RFC 2544](https://www.ietf.org/rfc/rfc2544.txt)

[Raymarine Camera Docs](https://www.raymarine.com/en-us/download/cam300-manuals)

## Testing

Verified patch works on customer machine with live Raymarine cam setup.

viamrtsp `0.5.9-rc1`