### PR TITLE
Add garmin discovery service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ ifeq ($(TARGET_OS),windows)
 endif
 BIN_VIAMRTSP := $(BIN_OUTPUT_PATH)/viamrtsp$(BIN_SUFFIX)
 BIN_DISCOVERY := $(BIN_OUTPUT_PATH)/discovery$(BIN_SUFFIX)
+BIN_GARMIN := $(BIN_OUTPUT_PATH)/garmin$(BIN_SUFFIX)
 TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 
 FFMPEG_TAG ?= n6.1
@@ -142,7 +143,7 @@ endif
 endif
 endif
 
-.PHONY: build-ffmpeg tool-install gofmt lint lint-ci test profile-cpu profile-memory update-rdk module clean clean-all install-deps viam-server
+.PHONY: build-ffmpeg tool-install gofmt lint lint-ci test profile-cpu profile-memory update-rdk module garmin clean clean-all install-deps viam-server
 
 all: $(BIN_VIAMRTSP) $(BIN_DISCOVERY)
 
@@ -186,6 +187,15 @@ $(BIN_DISCOVERY): build-ffmpeg *.go cmd/discovery/*.go
 	CGO_CFLAGS="$(CGO_CFLAGS)" \
 	GOOS=$(TARGET_OS) \
 	GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) -ldflags="-checklinkname=0" -o $(BIN_DISCOVERY) cmd/discovery/cmd.go
+
+$(BIN_GARMIN): build-ffmpeg *.go garmin/*.go cmd/garmin/*.go
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	CGO_CFLAGS="$(CGO_CFLAGS)" \
+	GOOS=$(TARGET_OS) \
+	GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) -ldflags="-checklinkname=0" -o $(BIN_GARMIN) cmd/garmin/cmd.go
+
+# Convenience phony target to build just the Garmin discovery debug binary.
+garmin: $(BIN_GARMIN)
 
 tool-install:
 	GOBIN=`pwd`/$(TOOL_BIN) go install \
@@ -318,7 +328,7 @@ module: $(BIN_VIAMRTSP)
 	rm bin/viamrtsp$(BIN_SUFFIX)
 
 clean:
-	rm -rf $(BIN_VIAMRTSP) $(BIN_DISCOVERY) module.tar.gz
+	rm -rf $(BIN_VIAMRTSP) $(BIN_DISCOVERY) $(BIN_GARMIN) module.tar.gz
 
 clean-all:
 	rm -rf FFmpeg

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ endif
 endif
 endif
 
-.PHONY: build-ffmpeg tool-install gofmt lint lint-ci test profile-cpu profile-memory update-rdk module garmin clean clean-all install-deps viam-server
+.PHONY: build-ffmpeg tool-install gofmt lint lint-ci test profile-cpu profile-memory update-rdk module clean clean-all install-deps viam-server
 
 all: $(BIN_VIAMRTSP) $(BIN_DISCOVERY)
 
@@ -193,9 +193,6 @@ $(BIN_GARMIN): build-ffmpeg *.go garmin/*.go cmd/garmin/*.go
 	CGO_CFLAGS="$(CGO_CFLAGS)" \
 	GOOS=$(TARGET_OS) \
 	GOARCH=$(TARGET_ARCH) go build $(GO_TAGS) -ldflags="-checklinkname=0" -o $(BIN_GARMIN) cmd/garmin/cmd.go
-
-# Convenience phony target to build just the Garmin discovery debug binary.
-garmin: $(BIN_GARMIN)
 
 tool-install:
 	GOBIN=`pwd`/$(TOOL_BIN) go install \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Five camera models are provided:
 This module also implements the `"rdk:service:discovery"` API to surface RTSP cameras based on their communication protocol:
 * `viam:viamrtsp:onvif` - discovers cameras using the [onvif interface](https://www.onvif.org/).
 * `viam:viamrtsp:unifi` - discovers cameras connected to a [UniFi Protect](https://ui.com/camera-security) NVR.
+* `viam:viamrtsp:garmin` - discovers [Garmin](https://www.garmin.com/en-US/c/marine/boat-cameras/) marine cameras that advertise over mDNS.
 
 This module also implements the `"rdk:service:video"` API for streaming stored video:
 * `viam:viamrtsp:video-service` - streams stored video from RTSP cameras using the `GetVideo` API.
@@ -386,6 +387,50 @@ The `DiscoverResources` API returns a list of cameras discovered from the NVR wi
 ### RTSP URL Conversion
 
 The UniFi Protect API returns RTSPS (secure) URLs on port 7441. This discovery service automatically converts them to plain RTSP on port 7447, which is more widely compatible with video clients.
+
+## Configure the `viamrtsp:garmin` discovery service
+
+This model discovers [Garmin](https://www.garmin.com/en-US/c/marine/boat-cameras/) marine cameras (such as the GC 100 / GC 200) on the local network. Garmin cameras are not ONVIF-discoverable; instead they advertise themselves over mDNS under the `_garmin-mrn-svcm._tcp` service type with a stable `*.local` hostname. This service browses for those advertisements and surfaces a camera configuration for each Garmin RTSP route.
+
+The machine running this service must be on the same network as the cameras so it can receive their mDNS broadcasts (Garmin networks are typically a `172.16.0.0/12` subnet). No attributes are required — the service discovers cameras automatically:
+
+```json
+{}
+```
+
+### Attributes
+
+| Name    | Type   | Inclusion    | Description |
+| ------- | ------ | ------------ | ----------- |
+| `rtsp_port` | int | Optional | The port the Garmin RTSP server listens on. Defaults to `8554`. |
+| `stream_paths` | []string | Optional | The RTSP routes to emit a camera config for, one config per route. Defaults to `["/Independent/480p", "/Independent/540p", "/Independent/720p"]`. |
+
+### Example Configuration
+
+```json
+{
+  "rtsp_port": 8554,
+  "stream_paths": ["/Independent/480p", "/Independent/540p", "/Independent/720p"]
+}
+```
+
+### Camera Configs
+
+The `DiscoverResources` API returns a list of cameras discovered over mDNS, with one component configuration per configured route. The `rtsp_address` uses the camera's self-advertised mDNS hostname:
+
+```json
+{
+  "api": "rdk:component:camera",
+  "attributes": {
+    "rtsp_address": "rtsp://garmin-cv28-copepod-3530195020.local:8554/Independent/720p",
+    "rtp_passthrough": true
+  },
+  "model": "viam:viamrtsp:rtsp",
+  "name": "garmin-cv28-copepod-3530195020-Independent-720p"
+}
+```
+
+**Note:** Camera names are derived from the mDNS instance name with the route appended for disambiguation. If the advertised hostname is unavailable, the discovered IP address is used in the `rtsp_address` instead.
 
 ## Configure the `viamrtsp:video-service` video service
 

--- a/cmd/garmin/cmd.go
+++ b/cmd/garmin/cmd.go
@@ -1,0 +1,55 @@
+// This package is a standalone binary for trying out Garmin mDNS discovery. It
+// browses the local network for Garmin cameras and dumps the result as JSON.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/viam-modules/viamrtsp/garmin"
+	"go.viam.com/rdk/logging"
+)
+
+func main() {
+	if err := realMain(); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func realMain() error {
+	debug := flag.Bool("debug", false, "enable debug logging")
+	output := flag.String("output", "", "if set, also write the JSON to this file")
+	flag.Parse()
+
+	var logger logging.Logger
+	if *debug {
+		logger = logging.NewDebugLogger("garmin-discovery")
+	} else {
+		logger = logging.NewLogger("garmin-discovery")
+	}
+
+	cameras, err := garmin.DiscoverCameras(context.Background(), logger)
+	if err != nil {
+		return err
+	}
+
+	jsonBytes, err := json.MarshalIndent(cameras, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonBytes))
+
+	if *output != "" {
+		//nolint:mnd
+		if err := os.WriteFile(*output, jsonBytes, 0o600); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/garmin/cmd.go
+++ b/cmd/garmin/cmd.go
@@ -21,7 +21,7 @@ func main() {
 }
 
 func realMain() error {
-	debug := flag.Bool("debug", false, "enable debug logging")
+	debug := flag.Bool("debug", false, "enable debug logging (logs each discovered camera's host/ips)")
 	output := flag.String("output", "", "if set, also write the JSON to this file")
 	flag.Parse()
 
@@ -32,17 +32,20 @@ func realMain() error {
 		logger = logging.NewLogger("garmin-discovery")
 	}
 
-	cameras, err := garmin.DiscoverCameras(context.Background(), logger)
+	// Dump the camera resource configs the discovery service would emit
+	// (paste-able into a machine's components). Run with -debug to also see each
+	// discovered camera's host/ips logged, e.g. for direct ffmpeg testing.
+	configs, err := garmin.DiscoverConfigs(context.Background(), &garmin.Config{}, logger)
 	if err != nil {
 		return err
 	}
 
-	jsonBytes, err := json.MarshalIndent(cameras, "", "  ")
+	jsonBytes, err := json.MarshalIndent(configs, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(jsonBytes))
+	fmt.Fprintln(os.Stdout, string(jsonBytes))
 
 	if *output != "" {
 		//nolint:mnd

--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/viam-modules/viamrtsp"
+	"github.com/viam-modules/viamrtsp/garmin"
 	"github.com/viam-modules/viamrtsp/ptzclient"
 	"github.com/viam-modules/viamrtsp/unifi"
 	"github.com/viam-modules/viamrtsp/upnpdiscovery"
@@ -65,6 +66,10 @@ func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error 
 		return err
 	}
 	err = myMod.AddModelFromRegistry(ctx, discovery.API, upnpdiscovery.Model)
+	if err != nil {
+		return err
+	}
+	err = myMod.AddModelFromRegistry(ctx, discovery.API, garmin.Model)
 	if err != nil {
 		return err
 	}

--- a/garmin/discovery.go
+++ b/garmin/discovery.go
@@ -24,14 +24,14 @@ const (
 // Camera is a single Garmin camera discovered over mDNS.
 type Camera struct {
 	// Instance is the mDNS instance name, e.g. "garmin-cv28-copepod-3530195020".
-	Instance string
+	Instance string `json:"instance"`
 	// Host is the advertised hostname without the trailing dot, e.g.
 	// "garmin-cv28-copepod-3530195020.local". May be empty if not advertised.
-	Host string
+	Host string `json:"host"`
 	// IPs are the resolved IPv4 addresses for the host.
-	IPs []net.IP
+	IPs []net.IP `json:"ips"`
 	// Text holds the raw TXT records, retained for future enrichment.
-	Text []string
+	Text []string `json:"text"`
 }
 
 // addressHost returns the host to use when building an RTSP URL. We prefer the
@@ -45,6 +45,13 @@ func (c Camera) addressHost() string {
 		return c.IPs[0].String()
 	}
 	return ""
+}
+
+// DiscoverCameras browses the local network over mDNS and returns the
+// deduplicated set of Garmin cameras found. Exported for use by the standalone
+// cmd/garmin debug binary.
+func DiscoverCameras(ctx context.Context, logger logging.Logger) ([]Camera, error) {
+	return browseGarmin(ctx, logger)
 }
 
 // browseGarmin browses the local network over mDNS for Garmin cameras for the

--- a/garmin/discovery.go
+++ b/garmin/discovery.go
@@ -1,0 +1,102 @@
+package garmin
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/viamrobotics/zeroconf"
+	"go.viam.com/rdk/logging"
+)
+
+const (
+	// mdnsService is the DNS-SD service type Garmin marine cameras advertise.
+	mdnsService = "_garmin-mrn-svcm._tcp"
+	// mdnsDomain is the mDNS domain to browse.
+	mdnsDomain = "local"
+	// browseTimeout bounds how long we listen for mDNS responses during discovery.
+	browseTimeout = 5 * time.Second
+	// entriesBufferSize is the buffer size for the channel zeroconf pushes entries into.
+	entriesBufferSize = 100
+)
+
+// Camera is a single Garmin camera discovered over mDNS.
+type Camera struct {
+	// Instance is the mDNS instance name, e.g. "garmin-cv28-copepod-3530195020".
+	Instance string
+	// Host is the advertised hostname without the trailing dot, e.g.
+	// "garmin-cv28-copepod-3530195020.local". May be empty if not advertised.
+	Host string
+	// IPs are the resolved IPv4 addresses for the host.
+	IPs []net.IP
+	// Text holds the raw TXT records, retained for future enrichment.
+	Text []string
+}
+
+// addressHost returns the host to use when building an RTSP URL. We prefer the
+// camera's self-advertised mDNS hostname (Garmin advertises a stable *.local
+// name), falling back to the first resolved IPv4 address.
+func (c Camera) addressHost() string {
+	if c.Host != "" {
+		return c.Host
+	}
+	if len(c.IPs) > 0 {
+		return c.IPs[0].String()
+	}
+	return ""
+}
+
+// browseGarmin browses the local network over mDNS for Garmin cameras for the
+// duration of browseTimeout and returns the deduplicated set found.
+func browseGarmin(ctx context.Context, logger logging.Logger) ([]Camera, error) {
+	// zeroconf expects a *zap.SugaredLogger; massage the viam logger into one.
+	resolver, err := zeroconf.NewResolver(logger.Desugar().Sugar())
+	if err != nil {
+		return nil, err
+	}
+	defer resolver.Shutdown()
+
+	entries := make(chan *zeroconf.ServiceEntry, entriesBufferSize)
+	browseCtx, cancel := context.WithTimeout(ctx, browseTimeout)
+	defer cancel()
+
+	if err := resolver.Browse(browseCtx, mdnsService, mdnsDomain, entries); err != nil {
+		return nil, err
+	}
+
+	// Collect until the browse window closes. zeroconf may emit the same instance
+	// multiple times; dedupe by instance name, preferring entries that carry a
+	// resolved hostname/IP.
+	found := make(map[string]Camera)
+	for {
+		select {
+		case <-browseCtx.Done():
+			cams := make([]Camera, 0, len(found))
+			for _, c := range found {
+				cams = append(cams, c)
+			}
+			logger.Debugf("garmin mDNS browse found %d camera(s)", len(cams))
+			return cams, nil
+		case entry := <-entries:
+			if entry == nil {
+				continue
+			}
+			cam := serviceEntryToCamera(entry)
+			existing, ok := found[cam.Instance]
+			if !ok || (existing.addressHost() == "" && cam.addressHost() != "") {
+				found[cam.Instance] = cam
+			}
+		}
+	}
+}
+
+// serviceEntryToCamera converts a zeroconf ServiceEntry into a Camera.
+func serviceEntryToCamera(entry *zeroconf.ServiceEntry) Camera {
+	return Camera{
+		Instance: entry.Instance,
+		Host:     strings.TrimSuffix(entry.HostName, "."),
+		IPs:      entry.AddrIPv4,
+		Text:     entry.Text,
+	}
+}

--- a/garmin/discovery.go
+++ b/garmin/discovery.go
@@ -30,8 +30,6 @@ type Camera struct {
 	Host string `json:"host"`
 	// IPs are the resolved IPv4 addresses for the host.
 	IPs []net.IP `json:"ips"`
-	// Text holds the raw TXT records, retained for future enrichment.
-	Text []string `json:"text"`
 }
 
 // addressHost returns the host to use when building an RTSP URL. We prefer the
@@ -45,13 +43,6 @@ func (c Camera) addressHost() string {
 		return c.IPs[0].String()
 	}
 	return ""
-}
-
-// DiscoverCameras browses the local network over mDNS and returns the
-// deduplicated set of Garmin cameras found. Exported for use by the standalone
-// cmd/garmin debug binary.
-func DiscoverCameras(ctx context.Context, logger logging.Logger) ([]Camera, error) {
-	return browseGarmin(ctx, logger)
 }
 
 // browseGarmin browses the local network over mDNS for Garmin cameras for the
@@ -81,6 +72,7 @@ func browseGarmin(ctx context.Context, logger logging.Logger) ([]Camera, error) 
 		case <-browseCtx.Done():
 			cams := make([]Camera, 0, len(found))
 			for _, c := range found {
+				logger.Debugf("discovered garmin camera: instance=%s host=%s ips=%v", c.Instance, c.Host, c.IPs)
 				cams = append(cams, c)
 			}
 			logger.Debugf("garmin mDNS browse found %d camera(s)", len(cams))
@@ -104,6 +96,5 @@ func serviceEntryToCamera(entry *zeroconf.ServiceEntry) Camera {
 		Instance: entry.Instance,
 		Host:     strings.TrimSuffix(entry.HostName, "."),
 		IPs:      entry.AddrIPv4,
-		Text:     entry.Text,
 	}
 }

--- a/garmin/garmin.go
+++ b/garmin/garmin.go
@@ -109,12 +109,19 @@ func newDiscovery(_ context.Context, _ resource.Dependencies,
 // DiscoverResources browses for Garmin cameras over mDNS and returns a camera
 // config for each discovered camera (one per configured stream path).
 func (dis *garminDiscovery) DiscoverResources(ctx context.Context, _ map[string]any) ([]resource.Config, error) {
-	cameras, err := browseGarmin(ctx, dis.logger)
+	return DiscoverConfigs(ctx, dis.cfg, dis.logger)
+}
+
+// DiscoverConfigs browses for Garmin cameras and returns the camera resource
+// configs the discovery service would emit for them. Exported for use by the
+// standalone cmd/garmin debug binary.
+func DiscoverConfigs(ctx context.Context, cfg *Config, logger logging.Logger) ([]resource.Config, error) {
+	cameras, err := browseGarmin(ctx, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to browse for garmin cameras: %w", err)
 	}
 
-	return camerasToConfigs(cameras, dis.cfg, dis.logger)
+	return camerasToConfigs(cameras, cfg, logger)
 }
 
 // camerasToConfigs turns discovered cameras into camera resource configs. Pure

--- a/garmin/garmin.go
+++ b/garmin/garmin.go
@@ -26,13 +26,17 @@ import (
 // Model is the model for a Garmin discovery service for rtsp cameras.
 var Model = viamrtsp.Family.WithModel("garmin")
 
-const (
-	// defaultRTSPPort is the port Garmin's GStreamer RTSP server listens on.
-	defaultRTSPPort = 8554
-	// defaultStreamPath is the RTSP path Garmin cameras serve. Fixed across the
-	// models seen in the field; overridable via config if that changes.
-	defaultStreamPath = "/Independent/1080p"
-)
+// defaultRTSPPort is the port Garmin's GStreamer RTSP server listens on.
+const defaultRTSPPort = 8554
+
+// defaultStreamPaths are the RTSP routes Garmin cameras serve, confirmed by
+// probing live GC-series cameras in the field. One camera config is emitted per
+// route. Overridable via config if a model exposes a different set.
+var defaultStreamPaths = []string{
+	"/Independent/480p",
+	"/Independent/540p",
+	"/Independent/720p",
+}
 
 func init() {
 	resource.RegisterService(
@@ -78,7 +82,7 @@ func (cfg *Config) paths() []string {
 	if len(cfg.StreamPaths) > 0 {
 		return cfg.StreamPaths
 	}
-	return []string{defaultStreamPath}
+	return defaultStreamPaths
 }
 
 type garminDiscovery struct {

--- a/garmin/garmin.go
+++ b/garmin/garmin.go
@@ -1,0 +1,182 @@
+// Package garmin provides a discovery service that finds Garmin marine cameras
+// over mDNS and emits ready-to-use viamrtsp camera configs.
+//
+// Garmin cameras are not ONVIF-discoverable. They advertise themselves over
+// mDNS under the "_garmin-mrn-svcm._tcp" service type with a stable *.local
+// hostname, and serve an RTSP stream at a fixed path. This service browses for
+// those advertisements and turns each camera into a camera resource config,
+// removing the manual avahi-browse + hand-built-config workflow.
+package garmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/viam-modules/viamrtsp"
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/discovery"
+)
+
+// Model is the model for a Garmin discovery service for rtsp cameras.
+var Model = viamrtsp.Family.WithModel("garmin")
+
+const (
+	// defaultRTSPPort is the port Garmin's GStreamer RTSP server listens on.
+	defaultRTSPPort = 8554
+	// defaultStreamPath is the RTSP path Garmin cameras serve. Fixed across the
+	// models seen in the field; overridable via config if that changes.
+	defaultStreamPath = "/Independent/1080p"
+)
+
+func init() {
+	resource.RegisterService(
+		discovery.API,
+		Model,
+		resource.Registration[discovery.Service, *Config]{
+			Constructor: newDiscovery,
+		})
+}
+
+// Config is the config for the Garmin discovery service.
+type Config struct {
+	// RTSPPort overrides the RTSP port. Defaults to 8554 if unset.
+	RTSPPort int `json:"rtsp_port,omitempty"`
+	// StreamPaths overrides the RTSP path(s) to emit per camera. Defaults to
+	// ["/Independent/1080p"] if unset. One camera config is emitted per path.
+	StreamPaths []string `json:"stream_paths,omitempty"`
+}
+
+// Validate validates the discovery service config.
+func (cfg *Config) Validate(_ string) ([]string, []string, error) {
+	if cfg.RTSPPort < 0 || cfg.RTSPPort > 65535 {
+		return nil, nil, fmt.Errorf("rtsp_port %d out of range", cfg.RTSPPort)
+	}
+	for _, p := range cfg.StreamPaths {
+		if p == "" {
+			return nil, nil, errors.New("stream_paths entries cannot be empty")
+		}
+	}
+	return []string{}, nil, nil
+}
+
+// port returns the configured RTSP port or the default.
+func (cfg *Config) port() int {
+	if cfg.RTSPPort != 0 {
+		return cfg.RTSPPort
+	}
+	return defaultRTSPPort
+}
+
+// paths returns the configured stream paths or the default.
+func (cfg *Config) paths() []string {
+	if len(cfg.StreamPaths) > 0 {
+		return cfg.StreamPaths
+	}
+	return []string{defaultStreamPath}
+}
+
+type garminDiscovery struct {
+	resource.Named
+	resource.AlwaysRebuild
+	resource.TriviallyCloseable
+
+	cfg    *Config
+	logger logging.Logger
+}
+
+func newDiscovery(_ context.Context, _ resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
+) (discovery.Service, error) {
+	cfg, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &garminDiscovery{
+		Named:  conf.ResourceName().AsNamed(),
+		cfg:    cfg,
+		logger: logger,
+	}, nil
+}
+
+// DiscoverResources browses for Garmin cameras over mDNS and returns a camera
+// config for each discovered camera (one per configured stream path).
+func (dis *garminDiscovery) DiscoverResources(ctx context.Context, _ map[string]any) ([]resource.Config, error) {
+	cameras, err := browseGarmin(ctx, dis.logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to browse for garmin cameras: %w", err)
+	}
+
+	return camerasToConfigs(cameras, dis.cfg, dis.logger)
+}
+
+// camerasToConfigs turns discovered cameras into camera resource configs. Pure
+// (no I/O) so it can be unit-tested over ServiceEntry-derived fixtures.
+func camerasToConfigs(cameras []Camera, cfg *Config, logger logging.Logger) ([]resource.Config, error) {
+	configs := []resource.Config{}
+	paths := cfg.paths()
+	port := cfg.port()
+
+	for _, cam := range cameras {
+		host := cam.addressHost()
+		if host == "" {
+			logger.Warnf("skipping garmin camera %q: no hostname or IP advertised", cam.Instance)
+			continue
+		}
+
+		for _, path := range paths {
+			address := fmt.Sprintf("rtsp://%s:%d%s", host, port, path)
+			name := cameraName(cam.Instance, path, len(paths) > 1)
+			cfg, err := createCameraConfig(name, address)
+			if err != nil {
+				return nil, err
+			}
+			configs = append(configs, cfg)
+		}
+	}
+
+	return configs, nil
+}
+
+// nonNameChars matches runs of characters not allowed in a Viam resource name.
+var nonNameChars = regexp.MustCompile("[^a-zA-Z0-9_-]+")
+
+// cameraName builds a deterministic, sanitized component name from the mDNS
+// instance. When a camera yields multiple stream paths, the sanitized path is
+// appended to keep names unique and stable across reconfigures.
+func cameraName(instance, path string, multiPath bool) string {
+	name := strings.Trim(nonNameChars.ReplaceAllString(instance, "-"), "-")
+	if multiPath {
+		pathSuffix := strings.Trim(nonNameChars.ReplaceAllString(path, "-"), "-")
+		name = fmt.Sprintf("%s-%s", name, pathSuffix)
+	}
+	return name
+}
+
+// createCameraConfig builds a camera resource.Config for the given RTSP address.
+func createCameraConfig(name, address string) (resource.Config, error) {
+	// Use viamrtsp's Config struct so a breaking change surfaces at compile time.
+	rtpPassthrough := true
+	attributes := viamrtsp.Config{Address: address, RTPPassthrough: &rtpPassthrough}
+
+	jsonBytes, err := json.Marshal(attributes)
+	if err != nil {
+		return resource.Config{}, err
+	}
+	var result map[string]interface{}
+	if err = json.Unmarshal(jsonBytes, &result); err != nil {
+		return resource.Config{}, err
+	}
+
+	return resource.Config{
+		Name: name, API: camera.API, Model: viamrtsp.ModelAgnostic,
+		Attributes: result, ConvertedAttributes: &attributes,
+	}, nil
+}

--- a/garmin/garmin_test.go
+++ b/garmin/garmin_test.go
@@ -1,0 +1,145 @@
+package garmin
+
+import (
+	"net"
+	"testing"
+
+	"github.com/viam-modules/viamrtsp"
+	"github.com/viamrobotics/zeroconf"
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/test"
+)
+
+// newServiceEntry builds a zeroconf.ServiceEntry as the resolver would yield one.
+func newServiceEntry(instance, hostname, ipv4 string) *zeroconf.ServiceEntry {
+	entry := zeroconf.NewServiceEntry(instance, mdnsService, mdnsDomain)
+	entry.HostName = hostname
+	if ipv4 != "" {
+		entry.AddrIPv4 = []net.IP{net.ParseIP(ipv4)}
+	}
+	return entry
+}
+
+func TestConfigDefaults(t *testing.T) {
+	t.Run("empty config uses garmin defaults", func(t *testing.T) {
+		cfg := &Config{}
+		test.That(t, cfg.port(), test.ShouldEqual, defaultRTSPPort)
+		test.That(t, cfg.paths(), test.ShouldResemble, []string{defaultStreamPath})
+	})
+
+	t.Run("overrides are respected", func(t *testing.T) {
+		cfg := &Config{RTSPPort: 9000, StreamPaths: []string{"/a", "/b"}}
+		test.That(t, cfg.port(), test.ShouldEqual, 9000)
+		test.That(t, cfg.paths(), test.ShouldResemble, []string{"/a", "/b"})
+	})
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		_, _, err := (&Config{RTSPPort: 8554, StreamPaths: []string{"/x"}}).Validate("")
+		test.That(t, err, test.ShouldBeNil)
+	})
+	t.Run("port out of range", func(t *testing.T) {
+		_, _, err := (&Config{RTSPPort: 70000}).Validate("")
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+	t.Run("empty stream path", func(t *testing.T) {
+		_, _, err := (&Config{StreamPaths: []string{""}}).Validate("")
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+}
+
+func TestAddressHost(t *testing.T) {
+	t.Run("prefers advertised hostname", func(t *testing.T) {
+		cam := Camera{Host: "garmin-cv28-x.local", IPs: []net.IP{net.ParseIP("172.16.0.5")}}
+		test.That(t, cam.addressHost(), test.ShouldEqual, "garmin-cv28-x.local")
+	})
+	t.Run("falls back to IP when no hostname", func(t *testing.T) {
+		cam := Camera{IPs: []net.IP{net.ParseIP("172.16.0.5")}}
+		test.That(t, cam.addressHost(), test.ShouldEqual, "172.16.0.5")
+	})
+	t.Run("empty when nothing advertised", func(t *testing.T) {
+		test.That(t, Camera{}.addressHost(), test.ShouldEqual, "")
+	})
+}
+
+func TestServiceEntryToCamera(t *testing.T) {
+	// HostName comes with a trailing dot from mDNS; it should be stripped.
+	cam := serviceEntryToCamera(newServiceEntry("garmin-cv28-copepod-3530195020", "garmin-cv28-copepod-3530195020.local.", "172.16.0.5"))
+	test.That(t, cam.Instance, test.ShouldEqual, "garmin-cv28-copepod-3530195020")
+	test.That(t, cam.Host, test.ShouldEqual, "garmin-cv28-copepod-3530195020.local")
+	test.That(t, cam.IPs[0].String(), test.ShouldEqual, "172.16.0.5")
+}
+
+func TestCameraName(t *testing.T) {
+	t.Run("single path uses sanitized instance", func(t *testing.T) {
+		test.That(t, cameraName("garmin-cv28-copepod-3530195020", "/Independent/1080p", false),
+			test.ShouldEqual, "garmin-cv28-copepod-3530195020")
+	})
+	t.Run("multi path appends sanitized path", func(t *testing.T) {
+		test.That(t, cameraName("garmin-cv28", "/Independent/1080p", true),
+			test.ShouldEqual, "garmin-cv28-Independent-1080p")
+	})
+	t.Run("strips invalid characters", func(t *testing.T) {
+		test.That(t, cameraName("garmin cv28!@#copepod", "/x", false),
+			test.ShouldEqual, "garmin-cv28-copepod")
+	})
+}
+
+func TestCamerasToConfigs(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	t.Run("default path emits one camera config per camera", func(t *testing.T) {
+		cams := []Camera{{Instance: "garmin-cv28-x", Host: "garmin-cv28-x.local"}}
+		configs, err := camerasToConfigs(cams, &Config{}, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(configs), test.ShouldEqual, 1)
+
+		cfg := configs[0]
+		test.That(t, cfg.Name, test.ShouldEqual, "garmin-cv28-x")
+		test.That(t, cfg.API, test.ShouldResemble, camera.API)
+		test.That(t, cfg.Model, test.ShouldResemble, viamrtsp.ModelAgnostic)
+
+		rtsp, ok := cfg.ConvertedAttributes.(*viamrtsp.Config)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, rtsp.Address, test.ShouldEqual, "rtsp://garmin-cv28-x.local:8554/Independent/1080p")
+		test.That(t, *rtsp.RTPPassthrough, test.ShouldBeTrue)
+	})
+
+	t.Run("multiple paths emit a config per path with unique names", func(t *testing.T) {
+		cams := []Camera{{Instance: "garmin-cv28-x", Host: "garmin-cv28-x.local"}}
+		cfg := &Config{StreamPaths: []string{"/Independent/1080p", "/Independent/720p"}}
+		configs, err := camerasToConfigs(cams, cfg, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(configs), test.ShouldEqual, 2)
+		test.That(t, configs[0].Name, test.ShouldNotEqual, configs[1].Name)
+	})
+
+	t.Run("falls back to IP when no hostname advertised", func(t *testing.T) {
+		cams := []Camera{{Instance: "garmin-cv28-x", IPs: []net.IP{net.ParseIP("172.16.0.5")}}}
+		configs, err := camerasToConfigs(cams, &Config{}, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(configs), test.ShouldEqual, 1)
+		rtsp := configs[0].ConvertedAttributes.(*viamrtsp.Config)
+		test.That(t, rtsp.Address, test.ShouldEqual, "rtsp://172.16.0.5:8554/Independent/1080p")
+	})
+
+	t.Run("skips cameras with neither hostname nor IP", func(t *testing.T) {
+		cams := []Camera{{Instance: "garmin-cv28-x"}}
+		configs, err := camerasToConfigs(cams, &Config{}, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, configs, test.ShouldBeEmpty)
+	})
+}
+
+func TestCreateCameraConfig(t *testing.T) {
+	cfg, err := createCameraConfig("cam0", "rtsp://host:8554/path")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, cfg.Name, test.ShouldEqual, "cam0")
+	// Attributes map must round-trip the address so viam-server can read it raw.
+	test.That(t, cfg.Attributes["rtsp_address"], test.ShouldEqual, "rtsp://host:8554/path")
+
+	var _ resource.Config = cfg
+}

--- a/garmin/garmin_test.go
+++ b/garmin/garmin_test.go
@@ -1,6 +1,7 @@
 package garmin
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 
@@ -132,6 +133,29 @@ func TestCamerasToConfigs(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, configs, test.ShouldBeEmpty)
 	})
+}
+
+func TestCameraConfigMarshalsToMachineConfig(t *testing.T) {
+	// The debug binary dumps these configs as JSON; lock the shape a user sees.
+	logger := logging.NewTestLogger(t)
+	configs, err := camerasToConfigs(
+		[]Camera{{Instance: "garmin-cv28-copepod-3530195020", Host: "garmin-cv28-copepod-3530195020.local"}},
+		&Config{}, logger,
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	jsonBytes, err := json.Marshal(configs[0])
+	test.That(t, err, test.ShouldBeNil)
+
+	var got map[string]any
+	test.That(t, json.Unmarshal(jsonBytes, &got), test.ShouldBeNil)
+	test.That(t, got["name"], test.ShouldEqual, "garmin-cv28-copepod-3530195020")
+	test.That(t, got["api"], test.ShouldEqual, "rdk:component:camera")
+	test.That(t, got["model"], test.ShouldEqual, "viam:viamrtsp:rtsp")
+	attrs, ok := got["attributes"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, attrs["rtsp_address"], test.ShouldEqual, "rtsp://garmin-cv28-copepod-3530195020.local:8554/Independent/1080p")
+	test.That(t, attrs["rtp_passthrough"], test.ShouldBeTrue)
 }
 
 func TestCreateCameraConfig(t *testing.T) {

--- a/garmin/garmin_test.go
+++ b/garmin/garmin_test.go
@@ -27,7 +27,7 @@ func TestConfigDefaults(t *testing.T) {
 	t.Run("empty config uses garmin defaults", func(t *testing.T) {
 		cfg := &Config{}
 		test.That(t, cfg.port(), test.ShouldEqual, defaultRTSPPort)
-		test.That(t, cfg.paths(), test.ShouldResemble, []string{defaultStreamPath})
+		test.That(t, cfg.paths(), test.ShouldResemble, defaultStreamPaths)
 	})
 
 	t.Run("overrides are respected", func(t *testing.T) {
@@ -92,21 +92,27 @@ func TestCameraName(t *testing.T) {
 func TestCamerasToConfigs(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
-	t.Run("default path emits one camera config per camera", func(t *testing.T) {
+	t.Run("default config emits one camera config per route", func(t *testing.T) {
 		cams := []Camera{{Instance: "garmin-cv28-x", Host: "garmin-cv28-x.local"}}
 		configs, err := camerasToConfigs(cams, &Config{}, logger)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(configs), test.ShouldEqual, 1)
+		test.That(t, len(configs), test.ShouldEqual, len(defaultStreamPaths))
 
-		cfg := configs[0]
-		test.That(t, cfg.Name, test.ShouldEqual, "garmin-cv28-x")
-		test.That(t, cfg.API, test.ShouldResemble, camera.API)
-		test.That(t, cfg.Model, test.ShouldResemble, viamrtsp.ModelAgnostic)
-
-		rtsp, ok := cfg.ConvertedAttributes.(*viamrtsp.Config)
-		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, rtsp.Address, test.ShouldEqual, "rtsp://garmin-cv28-x.local:8554/Independent/1080p")
-		test.That(t, *rtsp.RTPPassthrough, test.ShouldBeTrue)
+		// Each config points at a distinct route and has a unique name.
+		gotAddrs := map[string]bool{}
+		gotNames := map[string]bool{}
+		for _, cfg := range configs {
+			test.That(t, cfg.API, test.ShouldResemble, camera.API)
+			test.That(t, cfg.Model, test.ShouldResemble, viamrtsp.ModelAgnostic)
+			rtsp, ok := cfg.ConvertedAttributes.(*viamrtsp.Config)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, *rtsp.RTPPassthrough, test.ShouldBeTrue)
+			gotAddrs[rtsp.Address] = true
+			gotNames[cfg.Name] = true
+		}
+		test.That(t, len(gotAddrs), test.ShouldEqual, len(defaultStreamPaths))
+		test.That(t, len(gotNames), test.ShouldEqual, len(defaultStreamPaths))
+		test.That(t, gotAddrs["rtsp://garmin-cv28-x.local:8554/Independent/540p"], test.ShouldBeTrue)
 	})
 
 	t.Run("multiple paths emit a config per path with unique names", func(t *testing.T) {
@@ -120,11 +126,11 @@ func TestCamerasToConfigs(t *testing.T) {
 
 	t.Run("falls back to IP when no hostname advertised", func(t *testing.T) {
 		cams := []Camera{{Instance: "garmin-cv28-x", IPs: []net.IP{net.ParseIP("172.16.0.5")}}}
-		configs, err := camerasToConfigs(cams, &Config{}, logger)
+		configs, err := camerasToConfigs(cams, &Config{StreamPaths: []string{"/Independent/720p"}}, logger)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(configs), test.ShouldEqual, 1)
 		rtsp := configs[0].ConvertedAttributes.(*viamrtsp.Config)
-		test.That(t, rtsp.Address, test.ShouldEqual, "rtsp://172.16.0.5:8554/Independent/1080p")
+		test.That(t, rtsp.Address, test.ShouldEqual, "rtsp://172.16.0.5:8554/Independent/720p")
 	})
 
 	t.Run("skips cameras with neither hostname nor IP", func(t *testing.T) {
@@ -140,7 +146,7 @@ func TestCameraConfigMarshalsToMachineConfig(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	configs, err := camerasToConfigs(
 		[]Camera{{Instance: "garmin-cv28-copepod-3530195020", Host: "garmin-cv28-copepod-3530195020.local"}},
-		&Config{}, logger,
+		&Config{StreamPaths: []string{"/Independent/720p"}}, logger,
 	)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -154,7 +160,7 @@ func TestCameraConfigMarshalsToMachineConfig(t *testing.T) {
 	test.That(t, got["model"], test.ShouldEqual, "viam:viamrtsp:rtsp")
 	attrs, ok := got["attributes"].(map[string]any)
 	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, attrs["rtsp_address"], test.ShouldEqual, "rtsp://garmin-cv28-copepod-3530195020.local:8554/Independent/1080p")
+	test.That(t, attrs["rtsp_address"], test.ShouldEqual, "rtsp://garmin-cv28-copepod-3530195020.local:8554/Independent/720p")
 	test.That(t, attrs["rtp_passthrough"], test.ShouldBeTrue)
 }
 


### PR DESCRIPTION
## Description

Garmin discovery service - uses zerconf mDNS client to query for the garmin service type `_garmin-mrn-svcm._tcp`. This means it should work cross platform and avoids having to shell out to mDNS cli tools like avahi.

## Tests
- unit tests
- standalone garmin binary tested on customer machine

```
[
  {
    "name": "copepod3523445778",
    "api": "rdk:component:camera",
    "model": "viam:viamrtsp:rtsp",
    "attributes": {
      "query": {
        "manufacturer": "",
        "model_name": "",
        "network": "",
        "serial_number": ""
      },
      "rtp_passthrough": true,
      "rtsp_address": "rtsp://garmin-cv28-copepod-3523445778.local:8554/Independent/1080p"
    }
  },
  {
    "name": "copepod3530195142",
    "api": "rdk:component:camera",
    "model": "viam:viamrtsp:rtsp",
    "attributes": {
      "query": {
        "manufacturer": "",
        "model_name": "",
        "network": "",
        "serial_number": ""
      },
      "rtp_passthrough": true,
      "rtsp_address": "rtsp://garmin-cv28-copepod-3530195142.local:8554/Independent/1080p"
    }
  },
  {
    "name": "copepod3530195020",
    "api": "rdk:component:camera",
    "model": "viam:viamrtsp:rtsp",
    "attributes": {
      "query": {
        "manufacturer": "",
        "model_name": "",
        "network": "",
        "serial_number": ""
      },
      "rtp_passthrough": true,
      "rtsp_address": "rtsp://garmin-cv28-copepod-3530195020.local:8554/Independent/1080p"
    }
  },
  {
    "name": "copepod3530195034",
    "api": "rdk:component:camera",
    "model": "viam:viamrtsp:rtsp",
    "attributes": {
      "query": {
        "manufacturer": "",
        "model_name": "",
        "network": "",
        "serial_number": ""
      },
      "rtp_passthrough": true,
      "rtsp_address": "rtsp://garmin-cv28-copepod-3530195034.local:8554/Independent/1080p"
    }
  },
  {
    "name": "copepod3528665572",
    "api": "rdk:component:camera",
    "model": "viam:viamrtsp:rtsp",
    "attributes": {
      "query": {
        "manufacturer": "",
        "model_name": "",
        "network": "",
        "serial_number": ""
      },
      "rtp_passthrough": true,
      "rtsp_address": "rtsp://garmin-cv28-copepod-3528665572.local:8554/Independent/1080p"
    }
  },
  {
    "name": "copepod3530195052",
    "api": "rdk:component:camera",
    "model": "viam:viamrtsp:rtsp",
    "attributes": {
      "query": {
        "manufacturer": "",
        "model_name": "",
        "network": "",
        "serial_number": ""
      },
      "rtp_passthrough": true,
      "rtsp_address": "rtsp://garmin-cv28-copepod-3530195052.local:8554/Independent/1080p"
    }
  }
]
```